### PR TITLE
Add opendataloader plugin for OCR extraction from PDFs and images

### DIFF
--- a/.github/workflows/test-parallel.yml
+++ b/.github/workflows/test-parallel.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Run test - ${{ matrix.test.name }}
         run: |
-          uv run pytest -xvs "${{ matrix.test.path }}" --basetemp="$RUNNER_TEMP/pytest-out"
+          sudo -E "$(which uv)" run pytest -xvs "${{ matrix.test.path }}" --basetemp="$RUNNER_TEMP/pytest-out"
         env:
           TWOCAPTCHA_API_KEY: ${{ secrets.TWOCAPTCHA_API_KEY }}
           CHROME_SANDBOX: "false"

--- a/.github/workflows/test-parallel.yml
+++ b/.github/workflows/test-parallel.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Run test - ${{ matrix.test.name }}
         run: |
-          sudo -E "$(which uv)" run pytest -xvs "${{ matrix.test.path }}" --basetemp="$RUNNER_TEMP/pytest-out"
+          uv run pytest -xvs "${{ matrix.test.path }}" --basetemp="$RUNNER_TEMP/pytest-out"
         env:
           TWOCAPTCHA_API_KEY: ${{ secrets.TWOCAPTCHA_API_KEY }}
           CHROME_SANDBOX: "false"

--- a/abx_plugins/plugins/opendataloader/config.json
+++ b/abx_plugins/plugins/opendataloader/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "OpenDataLoader",
-  "description": "OCR PDFs and images to extract structured text, tables, and metadata using opendataloader-pdf.",
+  "description": "Extract structured text, tables, and metadata from PDFs using opendataloader-pdf. Supports OCR for scanned PDFs via hybrid backend.",
   "type": "object",
   "additionalProperties": false,
   "required_plugins": [],
@@ -12,7 +12,7 @@
       "type": "boolean",
       "default": true,
       "x-aliases": ["SAVE_OPENDATALOADER", "USE_OPENDATALOADER"],
-      "description": "Enable OCR extraction with opendataloader-pdf"
+      "description": "Enable PDF text extraction with opendataloader-pdf"
     },
     "OPENDATALOADER_BINARY": {
       "type": "string",
@@ -24,7 +24,17 @@
       "default": 120,
       "minimum": 10,
       "x-fallback": "TIMEOUT",
-      "description": "Timeout for OCR extraction in seconds"
+      "description": "Timeout for PDF extraction in seconds"
+    },
+    "OPENDATALOADER_FORCE_OCR": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use hybrid OCR backend (--hybrid docling-fast) for scanned/image-based PDFs. Requires opendataloader-pdf-hybrid server running."
+    },
+    "OPENDATALOADER_HYBRID_URL": {
+      "type": "string",
+      "default": "",
+      "description": "URL of the opendataloader-pdf-hybrid server (e.g. http://localhost:5002). If empty, uses the default built-in URL."
     },
     "OPENDATALOADER_ARGS": {
       "type": "array",

--- a/abx_plugins/plugins/opendataloader/config.json
+++ b/abx_plugins/plugins/opendataloader/config.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenDataLoader",
+  "description": "OCR PDFs and images to extract structured text, tables, and metadata using opendataloader-pdf.",
+  "type": "object",
+  "additionalProperties": false,
+  "required_plugins": [],
+  "required_binaries": ["opendataloader-pdf"],
+  "output_mimetypes": ["text/plain", "text/markdown", "application/json"],
+  "properties": {
+    "OPENDATALOADER_ENABLED": {
+      "type": "boolean",
+      "default": true,
+      "x-aliases": ["SAVE_OPENDATALOADER", "USE_OPENDATALOADER"],
+      "description": "Enable OCR extraction with opendataloader-pdf"
+    },
+    "OPENDATALOADER_BINARY": {
+      "type": "string",
+      "default": "opendataloader-pdf",
+      "description": "Path to opendataloader-pdf binary"
+    },
+    "OPENDATALOADER_TIMEOUT": {
+      "type": "integer",
+      "default": 120,
+      "minimum": 10,
+      "x-fallback": "TIMEOUT",
+      "description": "Timeout for OCR extraction in seconds"
+    },
+    "OPENDATALOADER_ARGS": {
+      "type": "array",
+      "items": {"type": "string"},
+      "default": [],
+      "x-aliases": ["OPENDATALOADER_DEFAULT_ARGS"],
+      "description": "Default opendataloader-pdf arguments"
+    },
+    "OPENDATALOADER_ARGS_EXTRA": {
+      "type": "array",
+      "items": {"type": "string"},
+      "default": [],
+      "x-aliases": ["OPENDATALOADER_EXTRA_ARGS"],
+      "description": "Extra arguments to append to opendataloader-pdf command"
+    }
+  }
+}

--- a/abx_plugins/plugins/opendataloader/on_Crawl__42_opendataloader_install.finite.bg.py
+++ b/abx_plugins/plugins/opendataloader/on_Crawl__42_opendataloader_install.finite.bg.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+#
+# Emits opendataloader-pdf as a Binary dependency for the crawl, configured via environment variables.
+#
+# Usage:
+#     ./on_Crawl__42_opendataloader_install.py > events.jsonl
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from base.utils import get_env_bool, output_binary
+
+PLUGIN_DIR = Path(__file__).parent.name
+CRAWL_DIR = Path(os.environ.get("CRAWL_DIR", ".")).resolve()
+OUTPUT_DIR = CRAWL_DIR / PLUGIN_DIR
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+os.chdir(OUTPUT_DIR)
+
+
+def main():
+    opendataloader_enabled = get_env_bool("OPENDATALOADER_ENABLED", default=True)
+
+    if not opendataloader_enabled:
+        sys.exit(0)
+
+    output_binary(
+        name="opendataloader-pdf",
+        binproviders="env,pip",
+        overrides={"pip": {"install_args": ["opendataloader-pdf"]}},
+    )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/abx_plugins/plugins/opendataloader/on_Crawl__42_opendataloader_install.finite.bg.py
+++ b/abx_plugins/plugins/opendataloader/on_Crawl__42_opendataloader_install.finite.bg.py
@@ -30,6 +30,11 @@ def main():
     if not opendataloader_enabled:
         sys.exit(0)
 
+    # Honor OPENDATALOADER_BINARY: if set and the file exists, skip install
+    custom_binary = os.environ.get("OPENDATALOADER_BINARY", "").strip()
+    if custom_binary and Path(custom_binary).is_file():
+        sys.exit(0)
+
     output_binary(
         name="opendataloader-pdf",
         binproviders="env,pip",

--- a/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
@@ -7,19 +7,28 @@
 # ]
 # ///
 """
-OCR PDFs and images using opendataloader-pdf.
+Extract structured text from PDFs using opendataloader-pdf.
 
-Finds PDF and image files produced by other plugins (pdf, screenshot, responses,
-staticfile) and extracts structured text content using opendataloader-pdf.
+Finds all PDF files produced by other plugins (pdf, responses, staticfile)
+and extracts text, tables, and metadata from each one. Processes every PDF
+found, combining results into content.md, content.txt, and metadata.json.
+
+For scanned/image-based PDFs, set OPENDATALOADER_FORCE_OCR=true to use the
+hybrid OCR backend (requires opendataloader-pdf-hybrid server running).
 
 Usage: on_Snapshot__60_opendataloader.py --url=<url> --snapshot-id=<uuid> > events.jsonl
 
 Environment variables:
     OPENDATALOADER_BINARY: Path to opendataloader-pdf binary
     OPENDATALOADER_TIMEOUT: Timeout in seconds (default: 120)
+    OPENDATALOADER_FORCE_OCR: Enable hybrid OCR for scanned PDFs (default: false)
+    OPENDATALOADER_HYBRID_URL: URL of hybrid server (default: built-in)
     OPENDATALOADER_ARGS: Default opendataloader-pdf arguments (JSON array)
     OPENDATALOADER_ARGS_EXTRA: Extra arguments to append (JSON array)
     TIMEOUT: Fallback timeout
+
+Note: opendataloader-pdf handles PDF files only. Standalone images (JPG, PNG)
+      are not supported as input by this tool.
 """
 
 import json
@@ -48,14 +57,11 @@ OUTPUT_FILE = "content.md"
 TEXT_FILE = "content.txt"
 METADATA_FILE = "metadata.json"
 
-PDF_EXTENSIONS = (".pdf",)
-IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tiff", ".tif", ".gif")
 
+def find_pdf_sources() -> list[Path]:
+    """Find all PDF files from sibling plugin output directories.
 
-def find_pdf_and_image_sources() -> list[Path]:
-    """Find PDF and image files from sibling plugin output directories.
-
-    Searches for outputs from: pdf, screenshot, responses, staticfile plugins.
+    Searches for outputs from: pdf, responses, staticfile plugins.
     """
     search_patterns = [
         # PDF plugin output
@@ -63,41 +69,12 @@ def find_pdf_and_image_sources() -> list[Path]:
         "*_pdf/output.pdf",
         "pdf/*.pdf",
         "*_pdf/*.pdf",
-        # Screenshot plugin output
-        "screenshot/screenshot.png",
-        "*_screenshot/screenshot.png",
-        "screenshot/*.png",
-        "*_screenshot/*.png",
-        "screenshot/*.jpg",
-        "*_screenshot/*.jpg",
-        # Responses plugin output (PDFs and images served by the URL)
+        # Responses plugin output (PDFs served directly by the URL)
         "responses/**/*.pdf",
         "*_responses/**/*.pdf",
-        "responses/**/*.png",
-        "*_responses/**/*.png",
-        "responses/**/*.jpg",
-        "*_responses/**/*.jpg",
-        "responses/**/*.jpeg",
-        "*_responses/**/*.jpeg",
-        "responses/**/*.webp",
-        "*_responses/**/*.webp",
-        "responses/**/*.tiff",
-        "*_responses/**/*.tiff",
-        "responses/**/*.tif",
-        "*_responses/**/*.tif",
-        "responses/**/*.bmp",
-        "*_responses/**/*.bmp",
-        "responses/**/*.gif",
-        "*_responses/**/*.gif",
         # Staticfile plugin output
         "staticfile/**/*.pdf",
         "*_staticfile/**/*.pdf",
-        "staticfile/**/*.png",
-        "*_staticfile/**/*.png",
-        "staticfile/**/*.jpg",
-        "*_staticfile/**/*.jpg",
-        "staticfile/**/*.jpeg",
-        "*_staticfile/**/*.jpeg",
     ]
 
     found: list[Path] = []
@@ -110,10 +87,8 @@ def find_pdf_and_image_sources() -> list[Path]:
                 if resolved in seen:
                     continue
                 if match.is_file() and match.stat().st_size > 0:
-                    suffix = match.suffix.lower()
-                    if suffix in PDF_EXTENSIONS or suffix in IMAGE_EXTENSIONS:
-                        found.append(match)
-                        seen.add(resolved)
+                    found.append(match)
+                    seen.add(resolved)
 
     return found
 
@@ -148,20 +123,38 @@ def _run_opendataloader(binary: str, source_file: Path, fmt: str, out_dir: Path,
 
 def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
     """
-    OCR PDFs and images using opendataloader-pdf.
+    Extract text from all PDFs found using opendataloader-pdf.
+
+    Processes every PDF found across sibling plugin directories.
+    Results from all files are combined into the output.
 
     Returns: (status, output_str)
     """
     config = load_config()
     timeout = config.OPENDATALOADER_TIMEOUT
+    force_ocr = config.OPENDATALOADER_FORCE_OCR
+    hybrid_url = config.OPENDATALOADER_HYBRID_URL
     opendataloader_args = config.OPENDATALOADER_ARGS
     opendataloader_args_extra = config.OPENDATALOADER_ARGS_EXTRA
     extra_args = [*opendataloader_args, *opendataloader_args_extra]
 
-    # Find PDF/image sources from sibling plugins
-    sources = find_pdf_and_image_sources()
+    # When FORCE_OCR is enabled, use hybrid backend for scanned/image-based PDFs
+    if force_ocr:
+        # Only add if user hasn't already specified --hybrid in ARGS
+        has_hybrid = any(a.startswith("--hybrid") for a in extra_args)
+        if not has_hybrid:
+            extra_args.extend(["--hybrid", "docling-fast"])
+        if hybrid_url:
+            has_url = any(a.startswith("--hybrid-url") for a in extra_args)
+            if not has_url:
+                extra_args.extend(["--hybrid-url", hybrid_url])
+
+    # Find all PDF sources from sibling plugins
+    sources = find_pdf_sources()
     if not sources:
-        return "noresults", "No PDF or image sources found"
+        return "noresults", "No PDF sources found"
+
+    print(f"[opendataloader] Found {len(sources)} PDF(s) to process", file=sys.stderr)
 
     output_dir = Path(OUTPUT_DIR)
     all_md_parts: list[str] = []
@@ -169,6 +162,7 @@ def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
     metadata_records: list[dict] = []
 
     for source_file in sources:
+        print(f"[opendataloader] Processing: {source_file.name}", file=sys.stderr)
         try:
             # Run markdown extraction
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -244,7 +238,7 @@ def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
 @click.option("--url", required=True, help="URL being archived")
 @click.option("--snapshot-id", required=True, help="Snapshot UUID")
 def main(url: str, snapshot_id: str):
-    """OCR PDFs and images using opendataloader-pdf."""
+    """Extract structured text from PDFs using opendataloader-pdf."""
 
     try:
         config = load_config()

--- a/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
@@ -141,7 +141,7 @@ def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
     # When FORCE_OCR is enabled, use hybrid backend for scanned/image-based PDFs
     if force_ocr:
         # Only add if user hasn't already specified --hybrid in ARGS
-        has_hybrid = any(a.startswith("--hybrid") for a in extra_args)
+        has_hybrid = any(a == "--hybrid" or a.startswith("--hybrid=") for a in extra_args)
         if not has_hybrid:
             extra_args.extend(["--hybrid", "docling-fast"])
         if hybrid_url:

--- a/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
@@ -121,6 +121,21 @@ def _run_opendataloader(binary: str, source_file: Path, fmt: str, out_dir: Path,
     return None
 
 
+def _extract_single_pdf(binary: str, source_file: Path, timeout: int, extra_args: list[str]) -> tuple[str, str]:
+    """Run markdown + text extraction on a single PDF, return (md_content, text_content)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        md_out = _run_opendataloader(binary, source_file, "markdown", tmp, timeout, extra_args)
+        md_content = md_out.read_text(errors="ignore") if md_out else ""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        txt_out = _run_opendataloader(binary, source_file, "text", tmp, timeout, extra_args)
+        text_content = txt_out.read_text(errors="ignore") if txt_out else ""
+
+    return md_content, text_content
+
+
 def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
     """
     Extract text from all PDFs found using opendataloader-pdf.
@@ -163,20 +178,40 @@ def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
 
     binary_failed = False
 
+    # Build base args (without hybrid flags) for fallback when hybrid fails
+    base_args = [a for a in extra_args if not a.startswith("--hybrid")]
+    # Also remove the value arg following --hybrid (e.g. "docling-fast")
+    if force_ocr:
+        _filtered: list[str] = []
+        skip_next = False
+        for a in extra_args:
+            if skip_next:
+                skip_next = False
+                continue
+            if a.startswith("--hybrid"):
+                # Skip --hybrid and --hybrid-url along with their values
+                skip_next = True
+                continue
+            _filtered.append(a)
+        base_args = _filtered
+
     for source_file in sources:
         print(f"[opendataloader] Processing: {source_file.name}", file=sys.stderr)
         try:
-            # Run markdown extraction
-            with tempfile.TemporaryDirectory() as tmpdir:
-                tmp = Path(tmpdir)
-                md_out = _run_opendataloader(binary, source_file, "markdown", tmp, timeout, extra_args)
-                md_content = md_out.read_text(errors="ignore") if md_out else ""
+            md_content, text_content = _extract_single_pdf(
+                binary, source_file, timeout, extra_args,
+            )
 
-            # Run text extraction
-            with tempfile.TemporaryDirectory() as tmpdir:
-                tmp = Path(tmpdir)
-                txt_out = _run_opendataloader(binary, source_file, "text", tmp, timeout, extra_args)
-                text_content = txt_out.read_text(errors="ignore") if txt_out else ""
+            # If hybrid extraction produced nothing, retry without hybrid flags
+            if force_ocr and not md_content and not text_content and base_args != extra_args:
+                print(
+                    f"[opendataloader] Hybrid extraction failed for {source_file.name}, "
+                    "retrying without hybrid flags",
+                    file=sys.stderr,
+                )
+                md_content, text_content = _extract_single_pdf(
+                    binary, source_file, timeout, base_args,
+                )
 
             if not md_content and not text_content:
                 print(

--- a/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
@@ -190,7 +190,8 @@ def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
                 continue
             if a.startswith("--hybrid"):
                 # Skip --hybrid and --hybrid-url along with their values
-                skip_next = True
+                if "=" not in a:
+                    skip_next = True
                 continue
             _filtered.append(a)
         base_args = _filtered

--- a/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
@@ -161,6 +161,8 @@ def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
     all_text_parts: list[str] = []
     metadata_records: list[dict] = []
 
+    binary_failed = False
+
     for source_file in sources:
         print(f"[opendataloader] Processing: {source_file.name}", file=sys.stderr)
         try:
@@ -200,12 +202,22 @@ def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
                 file=sys.stderr,
             )
             continue
+        except (FileNotFoundError, PermissionError, OSError) as e:
+            print(
+                f"[opendataloader] Binary execution failed: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+            binary_failed = True
+            break
         except Exception as e:
             print(
                 f"[opendataloader] Error on {source_file.name}: {type(e).__name__}: {e}",
                 file=sys.stderr,
             )
             continue
+
+    if binary_failed:
+        return "failed", f"Binary '{binary}' could not be executed"
 
     if not all_md_parts and not all_text_parts:
         return "noresults", "No content extracted from sources"
@@ -231,7 +243,10 @@ def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
         ),
     )
 
-    return "succeeded", OUTPUT_FILE
+    # Return the primary output file that was actually written
+    if all_md_parts:
+        return "succeeded", OUTPUT_FILE
+    return "succeeded", TEXT_FILE
 
 
 @click.command()

--- a/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/on_Snapshot__60_opendataloader.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "pydantic-settings",
+#   "rich-click",
+# ]
+# ///
+"""
+OCR PDFs and images using opendataloader-pdf.
+
+Finds PDF and image files produced by other plugins (pdf, screenshot, responses,
+staticfile) and extracts structured text content using opendataloader-pdf.
+
+Usage: on_Snapshot__60_opendataloader.py --url=<url> --snapshot-id=<uuid> > events.jsonl
+
+Environment variables:
+    OPENDATALOADER_BINARY: Path to opendataloader-pdf binary
+    OPENDATALOADER_TIMEOUT: Timeout in seconds (default: 120)
+    OPENDATALOADER_ARGS: Default opendataloader-pdf arguments (JSON array)
+    OPENDATALOADER_ARGS_EXTRA: Extra arguments to append (JSON array)
+    TIMEOUT: Fallback timeout
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from base.utils import load_config, emit_archive_result, write_text_atomic
+
+import rich_click as click
+
+
+# Extractor metadata
+PLUGIN_NAME = "opendataloader"
+BIN_NAME = "opendataloader-pdf"
+BIN_PROVIDERS = "env,pip"
+PLUGIN_DIR = Path(__file__).resolve().parent.name
+SNAP_DIR = Path(os.environ.get("SNAP_DIR", ".")).resolve()
+OUTPUT_DIR = SNAP_DIR / PLUGIN_DIR
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+os.chdir(OUTPUT_DIR)
+OUTPUT_FILE = "content.md"
+TEXT_FILE = "content.txt"
+METADATA_FILE = "metadata.json"
+
+PDF_EXTENSIONS = (".pdf",)
+IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tiff", ".tif", ".gif")
+
+
+def find_pdf_and_image_sources() -> list[Path]:
+    """Find PDF and image files from sibling plugin output directories.
+
+    Searches for outputs from: pdf, screenshot, responses, staticfile plugins.
+    """
+    search_patterns = [
+        # PDF plugin output
+        "pdf/output.pdf",
+        "*_pdf/output.pdf",
+        "pdf/*.pdf",
+        "*_pdf/*.pdf",
+        # Screenshot plugin output
+        "screenshot/screenshot.png",
+        "*_screenshot/screenshot.png",
+        "screenshot/*.png",
+        "*_screenshot/*.png",
+        "screenshot/*.jpg",
+        "*_screenshot/*.jpg",
+        # Responses plugin output (PDFs and images served by the URL)
+        "responses/**/*.pdf",
+        "*_responses/**/*.pdf",
+        "responses/**/*.png",
+        "*_responses/**/*.png",
+        "responses/**/*.jpg",
+        "*_responses/**/*.jpg",
+        "responses/**/*.jpeg",
+        "*_responses/**/*.jpeg",
+        "responses/**/*.webp",
+        "*_responses/**/*.webp",
+        "responses/**/*.tiff",
+        "*_responses/**/*.tiff",
+        "responses/**/*.tif",
+        "*_responses/**/*.tif",
+        "responses/**/*.bmp",
+        "*_responses/**/*.bmp",
+        "responses/**/*.gif",
+        "*_responses/**/*.gif",
+        # Staticfile plugin output
+        "staticfile/**/*.pdf",
+        "*_staticfile/**/*.pdf",
+        "staticfile/**/*.png",
+        "*_staticfile/**/*.png",
+        "staticfile/**/*.jpg",
+        "*_staticfile/**/*.jpg",
+        "staticfile/**/*.jpeg",
+        "*_staticfile/**/*.jpeg",
+    ]
+
+    found: list[Path] = []
+    seen: set[str] = set()
+
+    for base in (Path.cwd(), Path.cwd().parent):
+        for pattern in search_patterns:
+            for match in base.glob(pattern):
+                resolved = str(match.resolve())
+                if resolved in seen:
+                    continue
+                if match.is_file() and match.stat().st_size > 0:
+                    suffix = match.suffix.lower()
+                    if suffix in PDF_EXTENSIONS or suffix in IMAGE_EXTENSIONS:
+                        found.append(match)
+                        seen.add(resolved)
+
+    return found
+
+
+def _run_opendataloader(binary: str, source_file: Path, fmt: str, out_dir: Path, timeout: int, extra_args: list[str]) -> Path | None:
+    """Run opendataloader-pdf on a single file with a given format, return output path or None."""
+    cmd = [binary, "-f", fmt, "-o", str(out_dir), "-q", *extra_args, str(source_file)]
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        text=True,
+    )
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="")
+    if result.returncode != 0:
+        return None
+
+    # opendataloader-pdf writes {input_stem}.{ext} in the output dir
+    stem = source_file.stem
+    ext_map = {"markdown": ".md", "text": ".txt", "json": ".json"}
+    expected = out_dir / f"{stem}{ext_map.get(fmt, '.md')}"
+    if expected.is_file() and expected.stat().st_size > 0:
+        return expected
+    # Fallback: find any new file in out_dir
+    for f in sorted(out_dir.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        if f.is_file() and f.stat().st_size > 0:
+            return f
+    return None
+
+
+def extract_opendataloader(url: str, binary: str) -> tuple[str, str]:
+    """
+    OCR PDFs and images using opendataloader-pdf.
+
+    Returns: (status, output_str)
+    """
+    config = load_config()
+    timeout = config.OPENDATALOADER_TIMEOUT
+    opendataloader_args = config.OPENDATALOADER_ARGS
+    opendataloader_args_extra = config.OPENDATALOADER_ARGS_EXTRA
+    extra_args = [*opendataloader_args, *opendataloader_args_extra]
+
+    # Find PDF/image sources from sibling plugins
+    sources = find_pdf_and_image_sources()
+    if not sources:
+        return "noresults", "No PDF or image sources found"
+
+    output_dir = Path(OUTPUT_DIR)
+    all_md_parts: list[str] = []
+    all_text_parts: list[str] = []
+    metadata_records: list[dict] = []
+
+    for source_file in sources:
+        try:
+            # Run markdown extraction
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                md_out = _run_opendataloader(binary, source_file, "markdown", tmp, timeout, extra_args)
+                md_content = md_out.read_text(errors="ignore") if md_out else ""
+
+            # Run text extraction
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                txt_out = _run_opendataloader(binary, source_file, "text", tmp, timeout, extra_args)
+                text_content = txt_out.read_text(errors="ignore") if txt_out else ""
+
+            if not md_content and not text_content:
+                print(
+                    f"[opendataloader] No content extracted from {source_file.name}",
+                    file=sys.stderr,
+                )
+                continue
+
+            if md_content:
+                all_md_parts.append(f"<!-- source: {source_file.name} -->\n{md_content}")
+            if text_content:
+                all_text_parts.append(text_content)
+
+            metadata_records.append({
+                "source_file": str(source_file.name),
+                "source_path": str(source_file),
+                "chars_extracted": len(md_content or text_content),
+            })
+
+        except subprocess.TimeoutExpired:
+            print(
+                f"[opendataloader] Timed out on {source_file.name} after {timeout}s",
+                file=sys.stderr,
+            )
+            continue
+        except Exception as e:
+            print(
+                f"[opendataloader] Error on {source_file.name}: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+            continue
+
+    if not all_md_parts and not all_text_parts:
+        return "noresults", "No content extracted from sources"
+
+    # Write combined output files
+    if all_md_parts:
+        combined_md = "\n\n---\n\n".join(all_md_parts)
+        write_text_atomic(output_dir / OUTPUT_FILE, combined_md)
+
+    if all_text_parts:
+        combined_text = "\n\n---\n\n".join(all_text_parts)
+        write_text_atomic(output_dir / TEXT_FILE, combined_text)
+
+    write_text_atomic(
+        output_dir / METADATA_FILE,
+        json.dumps(
+            {
+                "sources_processed": len(metadata_records),
+                "total_sources_found": len(sources),
+                "files": metadata_records,
+            },
+            indent=2,
+        ),
+    )
+
+    return "succeeded", OUTPUT_FILE
+
+
+@click.command()
+@click.option("--url", required=True, help="URL being archived")
+@click.option("--snapshot-id", required=True, help="Snapshot UUID")
+def main(url: str, snapshot_id: str):
+    """OCR PDFs and images using opendataloader-pdf."""
+
+    try:
+        config = load_config()
+
+        if not config.OPENDATALOADER_ENABLED:
+            print("Skipping opendataloader (OPENDATALOADER_ENABLED=False)", file=sys.stderr)
+            emit_archive_result("skipped", "OPENDATALOADER_ENABLED=False")
+            sys.exit(0)
+
+        # Get binary from environment
+        binary = config.OPENDATALOADER_BINARY
+
+        # Run extraction
+        status, output = extract_opendataloader(url, binary)
+        if status == "failed":
+            print(f"ERROR: {output}", file=sys.stderr)
+        emit_archive_result(status, output)
+        sys.exit(0 if status != "failed" else 1)
+
+    except Exception as e:
+        error = f"{type(e).__name__}: {e}"
+        print(f"ERROR: {error}", file=sys.stderr)
+        emit_archive_result("failed", error)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/abx_plugins/plugins/opendataloader/tests/test_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/tests/test_opendataloader.py
@@ -11,7 +11,6 @@ Tests verify:
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -38,16 +37,25 @@ _opendataloader_lib_root = None
 
 
 def get_opendataloader_binary_path():
-    """Get opendataloader-pdf binary path from PATH or by running install hooks."""
+    """Get opendataloader-pdf binary path using abx_pkg or install hooks."""
     global _opendataloader_binary_path
     if _opendataloader_binary_path and Path(_opendataloader_binary_path).is_file():
         return _opendataloader_binary_path
 
-    # Try finding it on PATH first (already installed)
-    found = shutil.which("opendataloader-pdf")
-    if found and Path(found).is_file():
-        _opendataloader_binary_path = found
-        return _opendataloader_binary_path
+    # Try loading via abx_pkg Binary API first
+    from abx_pkg import Binary, PipProvider, EnvProvider
+
+    try:
+        binary = Binary(
+            name="opendataloader-pdf",
+            binproviders=[PipProvider(), EnvProvider()],
+            overrides={"pip": {"install_args": ["opendataloader-pdf"]}},
+        ).load()
+        if binary and binary.abspath:
+            _opendataloader_binary_path = str(binary.abspath)
+            return _opendataloader_binary_path
+    except Exception:
+        pass
 
     # Fall back to install via real plugin hooks
     pip_hook = PLUGINS_ROOT / "pip" / "on_Binary__11_pip_install.py"

--- a/abx_plugins/plugins/opendataloader/tests/test_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/tests/test_opendataloader.py
@@ -140,8 +140,11 @@ def require_opendataloader_binary() -> str:
     return binary_path
 
 
-def _download_test_pdf() -> bytes:
-    """Download a small public PDF for testing. Tries multiple sources."""
+def _download_test_pdf() -> bytes | None:
+    """Download a small public PDF for testing. Tries multiple sources.
+
+    Returns PDF bytes, or None if all sources are unavailable.
+    """
     pdf_urls = [
         "https://unec.edu.az/application/uploads/2014/12/pdf-sample.pdf",
         "https://www.orimi.com/pdf-test.pdf",
@@ -153,7 +156,15 @@ def _download_test_pdf() -> bytes:
                 return resp.content
         except Exception:
             continue
-    pytest.fail("Could not download any test PDF from the web")
+    return None
+
+
+def _require_test_pdf() -> bytes:
+    """Download a test PDF or skip the test if unavailable."""
+    pdf = _download_test_pdf()
+    if pdf is None:
+        pytest.skip("Could not download test PDF (network unavailable)")
+    return pdf
 
 
 def test_hook_script_exists():
@@ -231,7 +242,7 @@ def test_noresults_without_sources():
 def test_extract_single_pdf():
     """Test extraction on a single real PDF downloaded from the web."""
     binary_path = require_opendataloader_binary()
-    pdf_content = _download_test_pdf()
+    pdf_content = _require_test_pdf()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
@@ -288,7 +299,7 @@ def test_extract_multiple_pdfs():
     the hook processes every one, not just the first.
     """
     binary_path = require_opendataloader_binary()
-    pdf_content = _download_test_pdf()
+    pdf_content = _require_test_pdf()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
@@ -352,7 +363,7 @@ def test_force_ocr_adds_hybrid_flag():
     but we verify the flag is passed by checking stderr output.
     """
     binary_path = require_opendataloader_binary()
-    pdf_content = _download_test_pdf()
+    pdf_content = _require_test_pdf()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
@@ -384,14 +395,32 @@ def test_force_ocr_adds_hybrid_flag():
         )
 
         # With FORCE_OCR, it will attempt --hybrid docling-fast.
-        # Without a running hybrid server, it should still succeed via fallback
-        # (--hybrid-fallback is true by default in opendataloader-pdf).
+        # The hook must not crash regardless of hybrid server availability.
         assert result.returncode == 0, f"Should not crash: {result.stderr}"
 
         record = parse_jsonl_output(result.stdout)
         assert record, "Should have ArchiveResult JSONL output"
-        # Accept succeeded (fallback worked) or noresults (hybrid failed, no fallback content)
-        assert record["status"] in ("succeeded", "noresults"), f"Unexpected: {record}"
+
+        if record["status"] == "noresults":
+            # Hybrid server not available and fallback didn't produce content.
+            # Skip content assertions but don't fake-pass — mark as skipped
+            # so CI visibility shows OCR extraction was NOT verified.
+            pytest.skip(
+                "Hybrid OCR server not available; cannot verify OCR extraction. "
+                "Run with a hybrid server to fully test FORCE_OCR."
+            )
+
+        assert record["status"] == "succeeded", (
+            f"FORCE_OCR should succeed or noresults (no hybrid server), got: {record}. "
+            f"stderr: {result.stderr}"
+        )
+
+        output_dir = snap_dir / "opendataloader"
+        # Verify actual content was extracted (not a no-op pass)
+        output_file = output_dir / record["output_str"]
+        assert output_file.exists(), f"Output file {record['output_str']} not created"
+        content = output_file.read_text(errors="ignore")
+        assert len(content) > 10, f"Output too short, extraction may be broken: {content!r}"
 
 
 if __name__ == "__main__":

--- a/abx_plugins/plugins/opendataloader/tests/test_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/tests/test_opendataloader.py
@@ -1,0 +1,343 @@
+"""
+Integration tests for opendataloader plugin.
+
+Tests verify:
+1. Hook script exists
+2. Install hooks can install opendataloader-pdf binary
+3. OCR extraction runs with real opendataloader-pdf binary on a real live PDF
+4. Config options work (enabled/disabled)
+5. Handles missing sources gracefully
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+import requests
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+from base.test_utils import parse_jsonl_output
+
+PLUGIN_DIR = Path(__file__).parent.parent
+PLUGINS_ROOT = PLUGIN_DIR.parent
+_OPENDATALOADER_HOOK = next(PLUGIN_DIR.glob("on_Snapshot__*_opendataloader.*"), None)
+if _OPENDATALOADER_HOOK is None:
+    raise FileNotFoundError(f"Hook not found in {PLUGIN_DIR}")
+OPENDATALOADER_HOOK = _OPENDATALOADER_HOOK
+TEST_URL = "https://example.com"
+
+# Module-level cache for binary path
+_opendataloader_binary_path = None
+_opendataloader_lib_root = None
+
+
+def get_opendataloader_binary_path():
+    """Get opendataloader-pdf binary path from PATH or by running install hooks."""
+    global _opendataloader_binary_path
+    if _opendataloader_binary_path and Path(_opendataloader_binary_path).is_file():
+        return _opendataloader_binary_path
+
+    # Try finding it on PATH first (already installed)
+    found = shutil.which("opendataloader-pdf")
+    if found and Path(found).is_file():
+        _opendataloader_binary_path = found
+        return _opendataloader_binary_path
+
+    # Fall back to install via real plugin hooks
+    pip_hook = PLUGINS_ROOT / "pip" / "on_Binary__11_pip_install.py"
+    crawl_hook = PLUGIN_DIR / "on_Crawl__42_opendataloader_install.finite.bg.py"
+    if not pip_hook.exists():
+        return None
+
+    binproviders = "*"
+    overrides = None
+
+    if crawl_hook.exists():
+        crawl_result = subprocess.run(
+            [sys.executable, str(crawl_hook)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        for line in crawl_result.stdout.strip().split("\n"):
+            if not line.strip().startswith("{"):
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if record.get("type") == "Binary" and record.get("name") == "opendataloader-pdf":
+                binproviders = record.get("binproviders", "*")
+                overrides = record.get("overrides")
+                break
+
+    global _opendataloader_lib_root
+    if not _opendataloader_lib_root:
+        _opendataloader_lib_root = tempfile.mkdtemp(prefix="opendataloader-lib-")
+
+    env = os.environ.copy()
+    env["LIB_DIR"] = str(Path(_opendataloader_lib_root) / "lib")
+    env["SNAP_DIR"] = str(Path(_opendataloader_lib_root) / "data")
+    env["CRAWL_DIR"] = str(Path(_opendataloader_lib_root) / "crawl")
+
+    cmd = [
+        sys.executable,
+        str(pip_hook),
+        "--binary-id",
+        str(uuid.uuid4()),
+        "--machine-id",
+        str(uuid.uuid4()),
+        "--name",
+        "opendataloader-pdf",
+        f"--binproviders={binproviders}",
+    ]
+    if overrides:
+        cmd.append(f"--overrides={json.dumps(overrides)}")
+
+    install_result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=env,
+    )
+    for line in install_result.stdout.strip().split("\n"):
+        if not line.strip().startswith("{"):
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if record.get("type") == "Binary" and record.get("name") == "opendataloader-pdf":
+            _opendataloader_binary_path = record.get("abspath")
+            return _opendataloader_binary_path
+
+    return None
+
+
+def require_opendataloader_binary() -> str:
+    binary_path = get_opendataloader_binary_path()
+    assert binary_path, (
+        "opendataloader-pdf installation failed. Install hook should install "
+        "the binary automatically in this test environment."
+    )
+    assert Path(binary_path).is_file(), f"opendataloader-pdf binary path invalid: {binary_path}"
+    return binary_path
+
+
+def test_hook_script_exists():
+    assert OPENDATALOADER_HOOK.exists(), f"Hook script not found: {OPENDATALOADER_HOOK}"
+
+
+def test_verify_deps_with_install_hooks():
+    binary_path = require_opendataloader_binary()
+    assert Path(binary_path).is_file(), f"Binary path must be a valid file: {binary_path}"
+
+
+def test_config_disabled_skips():
+    """Test that OPENDATALOADER_ENABLED=False skips extraction."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        env = os.environ.copy()
+        env["OPENDATALOADER_ENABLED"] = "False"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(OPENDATALOADER_HOOK),
+                "--url",
+                TEST_URL,
+                "--snapshot-id",
+                "test-disabled",
+            ],
+            cwd=tmpdir,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, f"Should exit 0 when disabled: {result.stderr}"
+        result_json = parse_jsonl_output(result.stdout)
+        assert result_json, "Expected skipped JSONL output"
+        assert result_json["status"] == "skipped", result_json
+        assert result_json["output_str"] == "OPENDATALOADER_ENABLED=False", result_json
+
+
+def test_noresults_without_sources():
+    """Test that hook reports noresults when no PDF/image sources exist."""
+    binary_path = require_opendataloader_binary()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        snap_dir = tmpdir / "snap"
+        snap_dir.mkdir(parents=True, exist_ok=True)
+
+        env = os.environ.copy()
+        env["SNAP_DIR"] = str(snap_dir)
+        env["OPENDATALOADER_BINARY"] = binary_path
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(OPENDATALOADER_HOOK),
+                "--url",
+                TEST_URL,
+                "--snapshot-id",
+                "test-nosources",
+            ],
+            cwd=tmpdir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+        assert result.returncode == 0, "Should exit 0 without sources"
+        record = parse_jsonl_output(result.stdout)
+        assert record and record["status"] == "noresults"
+
+
+def test_ocr_real_pdf_from_web():
+    """Test OCR extraction on a real PDF downloaded from the web.
+
+    Downloads a public PDF, places it as if the pdf plugin produced it,
+    and runs the opendataloader snapshot hook to extract text.
+    """
+    binary_path = require_opendataloader_binary()
+
+    # Try multiple stable public PDF sources
+    pdf_urls = [
+        "https://unec.edu.az/application/uploads/2014/12/pdf-sample.pdf",
+        "https://www.orimi.com/pdf-test.pdf",
+    ]
+
+    pdf_content = None
+    for url in pdf_urls:
+        try:
+            resp = requests.get(url, timeout=30)
+            if resp.status_code == 200 and resp.content[:5] == b"%PDF-":
+                pdf_content = resp.content
+                break
+        except Exception:
+            continue
+
+    if pdf_content is None:
+        pytest.fail("Could not download any test PDF from the web")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        snap_dir = tmpdir / "snap"
+
+        # Place PDF as if the pdf plugin produced it
+        pdf_dir = snap_dir / "pdf"
+        pdf_dir.mkdir(parents=True, exist_ok=True)
+        pdf_file = pdf_dir / "output.pdf"
+        pdf_file.write_bytes(pdf_content)
+
+        env = os.environ.copy()
+        env["SNAP_DIR"] = str(snap_dir)
+        env["OPENDATALOADER_BINARY"] = binary_path
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(OPENDATALOADER_HOOK),
+                "--url",
+                "https://example.com/test.pdf",
+                "--snapshot-id",
+                "test-real-pdf",
+            ],
+            cwd=tmpdir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+
+        assert result.returncode == 0, f"OCR extraction failed: {result.stderr}"
+
+        record = parse_jsonl_output(result.stdout)
+        assert record, "Should have ArchiveResult JSONL output"
+        assert record["status"] == "succeeded", f"Should succeed: {record}. stderr: {result.stderr}"
+
+        output_dir = snap_dir / "opendataloader"
+        md_file = output_dir / "content.md"
+        txt_file = output_dir / "content.txt"
+        meta_file = output_dir / "metadata.json"
+
+        assert md_file.exists(), "content.md not created"
+        assert txt_file.exists(), "content.txt not created"
+        assert meta_file.exists(), "metadata.json not created"
+
+        md_content = md_file.read_text(errors="ignore")
+        assert len(md_content) > 10, f"content.md too short: {md_content!r}"
+
+        metadata = json.loads(meta_file.read_text())
+        assert metadata["sources_processed"] >= 1
+        assert metadata["files"][0]["source_file"] == "output.pdf"
+
+
+def test_ocr_image_from_responses():
+    """Test OCR extraction on an image placed as if the responses plugin produced it."""
+    binary_path = require_opendataloader_binary()
+
+    # Download a real image with text content (a table image from W3C)
+    image_url = "https://www.w3.org/WAI/WCAG21/Techniques/pdf/img/table-word.jpg"
+
+    try:
+        resp = requests.get(image_url, timeout=30)
+        resp.raise_for_status()
+        image_content = resp.content
+    except Exception as e:
+        pytest.fail(f"Could not download test image: {e}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        snap_dir = tmpdir / "snap"
+
+        # Place image as if responses plugin produced it
+        responses_dir = snap_dir / "responses" / "image" / "example.com"
+        responses_dir.mkdir(parents=True, exist_ok=True)
+        img_file = responses_dir / "table-word.jpg"
+        img_file.write_bytes(image_content)
+
+        env = os.environ.copy()
+        env["SNAP_DIR"] = str(snap_dir)
+        env["OPENDATALOADER_BINARY"] = binary_path
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(OPENDATALOADER_HOOK),
+                "--url",
+                "https://example.com/image.jpg",
+                "--snapshot-id",
+                "test-image-ocr",
+            ],
+            cwd=tmpdir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+
+        assert result.returncode == 0, f"Image OCR failed: {result.stderr}"
+
+        record = parse_jsonl_output(result.stdout)
+        assert record, "Should have ArchiveResult JSONL output"
+        # opendataloader-pdf handles PDFs; images may not be supported - accept noresults too
+        assert record["status"] in ("succeeded", "noresults"), f"Unexpected status: {record}"
+
+        if record["status"] == "succeeded":
+            output_dir = snap_dir / "opendataloader"
+            assert (output_dir / "content.md").exists(), "content.md not created"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/abx_plugins/plugins/opendataloader/tests/test_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/tests/test_opendataloader.py
@@ -4,9 +4,10 @@ Integration tests for opendataloader plugin.
 Tests verify:
 1. Hook script exists
 2. Install hooks can install opendataloader-pdf binary
-3. OCR extraction runs with real opendataloader-pdf binary on a real live PDF
-4. Config options work (enabled/disabled)
-5. Handles missing sources gracefully
+3. Extraction runs with real opendataloader-pdf binary on a real live PDF
+4. Multiple PDFs are all processed (not just the first)
+5. Config options work (enabled/disabled, FORCE_OCR)
+6. Handles missing sources gracefully
 """
 
 import json
@@ -139,6 +140,22 @@ def require_opendataloader_binary() -> str:
     return binary_path
 
 
+def _download_test_pdf() -> bytes:
+    """Download a small public PDF for testing. Tries multiple sources."""
+    pdf_urls = [
+        "https://unec.edu.az/application/uploads/2014/12/pdf-sample.pdf",
+        "https://www.orimi.com/pdf-test.pdf",
+    ]
+    for url in pdf_urls:
+        try:
+            resp = requests.get(url, timeout=30)
+            if resp.status_code == 200 and resp.content[:5] == b"%PDF-":
+                return resp.content
+        except Exception:
+            continue
+    pytest.fail("Could not download any test PDF from the web")
+
+
 def test_hook_script_exists():
     assert OPENDATALOADER_HOOK.exists(), f"Hook script not found: {OPENDATALOADER_HOOK}"
 
@@ -178,7 +195,7 @@ def test_config_disabled_skips():
 
 
 def test_noresults_without_sources():
-    """Test that hook reports noresults when no PDF/image sources exist."""
+    """Test that hook reports noresults when no PDF sources exist."""
     binary_path = require_opendataloader_binary()
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -211,32 +228,10 @@ def test_noresults_without_sources():
         assert record and record["status"] == "noresults"
 
 
-def test_ocr_real_pdf_from_web():
-    """Test OCR extraction on a real PDF downloaded from the web.
-
-    Downloads a public PDF, places it as if the pdf plugin produced it,
-    and runs the opendataloader snapshot hook to extract text.
-    """
+def test_extract_single_pdf():
+    """Test extraction on a single real PDF downloaded from the web."""
     binary_path = require_opendataloader_binary()
-
-    # Try multiple stable public PDF sources
-    pdf_urls = [
-        "https://unec.edu.az/application/uploads/2014/12/pdf-sample.pdf",
-        "https://www.orimi.com/pdf-test.pdf",
-    ]
-
-    pdf_content = None
-    for url in pdf_urls:
-        try:
-            resp = requests.get(url, timeout=30)
-            if resp.status_code == 200 and resp.content[:5] == b"%PDF-":
-                pdf_content = resp.content
-                break
-        except Exception:
-            continue
-
-    if pdf_content is None:
-        pytest.fail("Could not download any test PDF from the web")
+    pdf_content = _download_test_pdf()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
@@ -245,8 +240,7 @@ def test_ocr_real_pdf_from_web():
         # Place PDF as if the pdf plugin produced it
         pdf_dir = snap_dir / "pdf"
         pdf_dir.mkdir(parents=True, exist_ok=True)
-        pdf_file = pdf_dir / "output.pdf"
-        pdf_file.write_bytes(pdf_content)
+        (pdf_dir / "output.pdf").write_bytes(pdf_content)
 
         env = os.environ.copy()
         env["SNAP_DIR"] = str(snap_dir)
@@ -259,7 +253,7 @@ def test_ocr_real_pdf_from_web():
                 "--url",
                 "https://example.com/test.pdf",
                 "--snapshot-id",
-                "test-real-pdf",
+                "test-single-pdf",
             ],
             cwd=tmpdir,
             capture_output=True,
@@ -268,52 +262,47 @@ def test_ocr_real_pdf_from_web():
             env=env,
         )
 
-        assert result.returncode == 0, f"OCR extraction failed: {result.stderr}"
+        assert result.returncode == 0, f"Extraction failed: {result.stderr}"
 
         record = parse_jsonl_output(result.stdout)
         assert record, "Should have ArchiveResult JSONL output"
         assert record["status"] == "succeeded", f"Should succeed: {record}. stderr: {result.stderr}"
 
         output_dir = snap_dir / "opendataloader"
-        md_file = output_dir / "content.md"
-        txt_file = output_dir / "content.txt"
-        meta_file = output_dir / "metadata.json"
+        assert (output_dir / "content.md").exists(), "content.md not created"
+        assert (output_dir / "content.txt").exists(), "content.txt not created"
+        assert (output_dir / "metadata.json").exists(), "metadata.json not created"
 
-        assert md_file.exists(), "content.md not created"
-        assert txt_file.exists(), "content.txt not created"
-        assert meta_file.exists(), "metadata.json not created"
-
-        md_content = md_file.read_text(errors="ignore")
+        md_content = (output_dir / "content.md").read_text(errors="ignore")
         assert len(md_content) > 10, f"content.md too short: {md_content!r}"
 
-        metadata = json.loads(meta_file.read_text())
-        assert metadata["sources_processed"] >= 1
+        metadata = json.loads((output_dir / "metadata.json").read_text())
+        assert metadata["sources_processed"] == 1
         assert metadata["files"][0]["source_file"] == "output.pdf"
 
 
-def test_ocr_image_from_responses():
-    """Test OCR extraction on an image placed as if the responses plugin produced it."""
+def test_extract_multiple_pdfs():
+    """Test that ALL PDFs are processed when multiple exist across plugins.
+
+    Places PDFs in both pdf/ and responses/ directories and verifies
+    the hook processes every one, not just the first.
+    """
     binary_path = require_opendataloader_binary()
-
-    # Download a real image with text content (a table image from W3C)
-    image_url = "https://www.w3.org/WAI/WCAG21/Techniques/pdf/img/table-word.jpg"
-
-    try:
-        resp = requests.get(image_url, timeout=30)
-        resp.raise_for_status()
-        image_content = resp.content
-    except Exception as e:
-        pytest.fail(f"Could not download test image: {e}")
+    pdf_content = _download_test_pdf()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
         snap_dir = tmpdir / "snap"
 
-        # Place image as if responses plugin produced it
-        responses_dir = snap_dir / "responses" / "image" / "example.com"
+        # Place PDF in pdf/ plugin output
+        pdf_dir = snap_dir / "pdf"
+        pdf_dir.mkdir(parents=True, exist_ok=True)
+        (pdf_dir / "output.pdf").write_bytes(pdf_content)
+
+        # Place another PDF in responses/ as if the server served a PDF
+        responses_dir = snap_dir / "responses" / "application" / "example.com"
         responses_dir.mkdir(parents=True, exist_ok=True)
-        img_file = responses_dir / "table-word.jpg"
-        img_file.write_bytes(image_content)
+        (responses_dir / "document.pdf").write_bytes(pdf_content)
 
         env = os.environ.copy()
         env["SNAP_DIR"] = str(snap_dir)
@@ -324,9 +313,9 @@ def test_ocr_image_from_responses():
                 sys.executable,
                 str(OPENDATALOADER_HOOK),
                 "--url",
-                "https://example.com/image.jpg",
+                "https://example.com/docs",
                 "--snapshot-id",
-                "test-image-ocr",
+                "test-multi-pdf",
             ],
             cwd=tmpdir,
             capture_output=True,
@@ -335,16 +324,74 @@ def test_ocr_image_from_responses():
             env=env,
         )
 
-        assert result.returncode == 0, f"Image OCR failed: {result.stderr}"
+        assert result.returncode == 0, f"Extraction failed: {result.stderr}"
 
         record = parse_jsonl_output(result.stdout)
         assert record, "Should have ArchiveResult JSONL output"
-        # opendataloader-pdf handles PDFs; images may not be supported - accept noresults too
-        assert record["status"] in ("succeeded", "noresults"), f"Unexpected status: {record}"
+        assert record["status"] == "succeeded", f"Should succeed: {record}"
 
-        if record["status"] == "succeeded":
-            output_dir = snap_dir / "opendataloader"
-            assert (output_dir / "content.md").exists(), "content.md not created"
+        output_dir = snap_dir / "opendataloader"
+        metadata = json.loads((output_dir / "metadata.json").read_text())
+        assert metadata["sources_processed"] == 2, (
+            f"Expected 2 PDFs processed, got {metadata['sources_processed']}. "
+            f"Files: {metadata['files']}"
+        )
+        assert metadata["total_sources_found"] == 2
+
+        # Verify combined output contains content from both files
+        md_content = (output_dir / "content.md").read_text(errors="ignore")
+        assert "---" in md_content or md_content.count("<!-- source:") >= 2, (
+            "Combined markdown should contain content from both PDFs"
+        )
+
+
+def test_force_ocr_adds_hybrid_flag():
+    """Test that OPENDATALOADER_FORCE_OCR=true adds --hybrid docling-fast to command.
+
+    Since no hybrid server is running, the extraction will fail/fallback,
+    but we verify the flag is passed by checking stderr output.
+    """
+    binary_path = require_opendataloader_binary()
+    pdf_content = _download_test_pdf()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        snap_dir = tmpdir / "snap"
+
+        pdf_dir = snap_dir / "pdf"
+        pdf_dir.mkdir(parents=True, exist_ok=True)
+        (pdf_dir / "output.pdf").write_bytes(pdf_content)
+
+        env = os.environ.copy()
+        env["SNAP_DIR"] = str(snap_dir)
+        env["OPENDATALOADER_BINARY"] = binary_path
+        env["OPENDATALOADER_FORCE_OCR"] = "true"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(OPENDATALOADER_HOOK),
+                "--url",
+                "https://example.com/scanned.pdf",
+                "--snapshot-id",
+                "test-force-ocr",
+            ],
+            cwd=tmpdir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+
+        # With FORCE_OCR, it will attempt --hybrid docling-fast.
+        # Without a running hybrid server, it should still succeed via fallback
+        # (--hybrid-fallback is true by default in opendataloader-pdf).
+        assert result.returncode == 0, f"Should not crash: {result.stderr}"
+
+        record = parse_jsonl_output(result.stdout)
+        assert record, "Should have ArchiveResult JSONL output"
+        # Accept succeeded (fallback worked) or noresults (hybrid failed, no fallback content)
+        assert record["status"] in ("succeeded", "noresults"), f"Unexpected: {record}"
 
 
 if __name__ == "__main__":

--- a/abx_plugins/plugins/opendataloader/tests/test_opendataloader.py
+++ b/abx_plugins/plugins/opendataloader/tests/test_opendataloader.py
@@ -140,11 +140,8 @@ def require_opendataloader_binary() -> str:
     return binary_path
 
 
-def _download_test_pdf() -> bytes | None:
-    """Download a small public PDF for testing. Tries multiple sources.
-
-    Returns PDF bytes, or None if all sources are unavailable.
-    """
+def _download_test_pdf() -> bytes:
+    """Download a small public PDF for testing. Tries multiple sources."""
     pdf_urls = [
         "https://unec.edu.az/application/uploads/2014/12/pdf-sample.pdf",
         "https://www.orimi.com/pdf-test.pdf",
@@ -156,15 +153,7 @@ def _download_test_pdf() -> bytes | None:
                 return resp.content
         except Exception:
             continue
-    return None
-
-
-def _require_test_pdf() -> bytes:
-    """Download a test PDF or skip the test if unavailable."""
-    pdf = _download_test_pdf()
-    if pdf is None:
-        pytest.skip("Could not download test PDF (network unavailable)")
-    return pdf
+    pytest.fail("Could not download any test PDF from the web")
 
 
 def test_hook_script_exists():
@@ -242,7 +231,7 @@ def test_noresults_without_sources():
 def test_extract_single_pdf():
     """Test extraction on a single real PDF downloaded from the web."""
     binary_path = require_opendataloader_binary()
-    pdf_content = _require_test_pdf()
+    pdf_content = _download_test_pdf()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
@@ -299,7 +288,7 @@ def test_extract_multiple_pdfs():
     the hook processes every one, not just the first.
     """
     binary_path = require_opendataloader_binary()
-    pdf_content = _require_test_pdf()
+    pdf_content = _download_test_pdf()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
@@ -363,7 +352,7 @@ def test_force_ocr_adds_hybrid_flag():
     but we verify the flag is passed by checking stderr output.
     """
     binary_path = require_opendataloader_binary()
-    pdf_content = _require_test_pdf()
+    pdf_content = _download_test_pdf()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
@@ -395,23 +384,14 @@ def test_force_ocr_adds_hybrid_flag():
         )
 
         # With FORCE_OCR, it will attempt --hybrid docling-fast.
-        # The hook must not crash regardless of hybrid server availability.
+        # If the hybrid server is unavailable, the hook must fall back to
+        # standard extraction and still succeed with real content.
         assert result.returncode == 0, f"Should not crash: {result.stderr}"
 
         record = parse_jsonl_output(result.stdout)
         assert record, "Should have ArchiveResult JSONL output"
-
-        if record["status"] == "noresults":
-            # Hybrid server not available and fallback didn't produce content.
-            # Skip content assertions but don't fake-pass — mark as skipped
-            # so CI visibility shows OCR extraction was NOT verified.
-            pytest.skip(
-                "Hybrid OCR server not available; cannot verify OCR extraction. "
-                "Run with a hybrid server to fully test FORCE_OCR."
-            )
-
         assert record["status"] == "succeeded", (
-            f"FORCE_OCR should succeed or noresults (no hybrid server), got: {record}. "
+            f"FORCE_OCR must succeed (with hybrid or via fallback), got: {record}. "
             f"stderr: {result.stderr}"
         )
 

--- a/abx_plugins/plugins/puppeteer/on_Binary__12_puppeteer_install.py
+++ b/abx_plugins/plugins/puppeteer/on_Binary__12_puppeteer_install.py
@@ -184,6 +184,7 @@ def _run_puppeteer_install(binary: Binary, install_args: list[str], cache_dir: P
             return sudo_proc
         if sudo_proc is not None:
             install_output = f"{sudo_proc.stdout}\n{sudo_proc.stderr}"
+            proc = sudo_proc
 
     if not _cleanup_partial_chromium_cache(install_output, cache_dir):
         return proc

--- a/abx_plugins/plugins/puppeteer/on_Binary__12_puppeteer_install.py
+++ b/abx_plugins/plugins/puppeteer/on_Binary__12_puppeteer_install.py
@@ -171,10 +171,43 @@ def _run_puppeteer_install(binary: Binary, install_args: list[str], cache_dir: P
         return proc
 
     install_output = f"{proc.stdout}\n{proc.stderr}"
+
+    # If --install-deps failed because we're not root, retry with sudo
+    if (
+        "--install-deps" in install_args
+        and "requires root privileges" in install_output
+        and os.geteuid() != 0
+        and shutil.which("sudo")
+    ):
+        sudo_proc = _run_puppeteer_install_with_sudo(binary, install_args, cache_dir)
+        if sudo_proc is not None:
+            return sudo_proc
+
     if not _cleanup_partial_chromium_cache(install_output, cache_dir):
         return proc
 
     return binary.exec(cmd=cmd, timeout=300)
+
+
+def _run_puppeteer_install_with_sudo(
+    binary: Binary, install_args: list[str], cache_dir: Path
+):
+    """Re-run puppeteer install via sudo so --install-deps can install system libs."""
+    import subprocess as _subprocess
+
+    abspath = str(binary.abspath or shutil.which("puppeteer") or "")
+    if not abspath:
+        return None
+
+    sudo_cmd = [
+        "sudo", "-E", abspath, "browsers", "install", *install_args,
+    ]
+    env = os.environ.copy()
+    env.setdefault("PUPPETEER_CACHE_DIR", str(cache_dir))
+    proc = _subprocess.run(
+        sudo_cmd, capture_output=True, text=True, timeout=300, env=env,
+    )
+    return proc
 
 
 def _cleanup_partial_chromium_cache(install_output: str, cache_dir: Path) -> bool:

--- a/abx_plugins/plugins/puppeteer/on_Binary__12_puppeteer_install.py
+++ b/abx_plugins/plugins/puppeteer/on_Binary__12_puppeteer_install.py
@@ -180,8 +180,10 @@ def _run_puppeteer_install(binary: Binary, install_args: list[str], cache_dir: P
         and shutil.which("sudo")
     ):
         sudo_proc = _run_puppeteer_install_with_sudo(binary, install_args, cache_dir)
-        if sudo_proc is not None:
+        if sudo_proc is not None and sudo_proc.returncode == 0:
             return sudo_proc
+        if sudo_proc is not None:
+            install_output = f"{sudo_proc.stdout}\n{sudo_proc.stderr}"
 
     if not _cleanup_partial_chromium_cache(install_output, cache_dir):
         return proc

--- a/abx_plugins/plugins/puppeteer/on_Binary__12_puppeteer_install.py
+++ b/abx_plugins/plugins/puppeteer/on_Binary__12_puppeteer_install.py
@@ -209,6 +209,17 @@ def _run_puppeteer_install_with_sudo(
     proc = _subprocess.run(
         sudo_cmd, capture_output=True, text=True, timeout=300, env=env,
     )
+
+    # Fix ownership: sudo may have written root-owned files into the
+    # normal user's cache dir, which would break later non-root operations.
+    if proc.returncode == 0 and cache_dir.exists():
+        uid = os.getuid()
+        gid = os.getgid()
+        _subprocess.run(
+            ["sudo", "chown", "-R", f"{uid}:{gid}", str(cache_dir)],
+            timeout=30,
+        )
+
     return proc
 
 

--- a/abx_plugins/plugins/search_backend_sonic/on_Snapshot__91_index_sonic.py
+++ b/abx_plugins/plugins/search_backend_sonic/on_Snapshot__91_index_sonic.py
@@ -49,6 +49,8 @@ INDEXABLE_FILES = [
     ("readability", "content.html"),
     ("mercury", "content.txt"),
     ("mercury", "content.html"),
+    ("opendataloader", "content.txt"),
+    ("opendataloader", "content.md"),
     ("htmltotext", "output.txt"),
     ("singlefile", "singlefile.html"),
     ("dom", "output.html"),

--- a/abx_plugins/plugins/search_backend_sonic/on_Snapshot__91_index_sonic.py
+++ b/abx_plugins/plugins/search_backend_sonic/on_Snapshot__91_index_sonic.py
@@ -43,21 +43,12 @@ SNAP_DIR = Path(os.environ.get("SNAP_DIR", ".")).resolve()
 OUTPUT_DIR = SNAP_DIR / PLUGIN_DIR
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 os.chdir(OUTPUT_DIR)
-# Text file patterns to index
-INDEXABLE_FILES = [
-    ("readability", "content.txt"),
-    ("readability", "content.html"),
-    ("mercury", "content.txt"),
-    ("mercury", "content.html"),
-    ("opendataloader", "content.txt"),
-    ("opendataloader", "content.md"),
-    ("htmltotext", "output.txt"),
-    ("singlefile", "singlefile.html"),
-    ("dom", "output.html"),
-    ("wget", "**/*.html"),
-    ("wget", "**/*.htm"),
-    ("title", "title.txt"),
-]
+# File extensions eligible for full-text indexing
+INDEXABLE_EXTENSIONS = {".txt", ".md", ".html", ".htm"}
+# Directories to skip (search backends themselves, executor artifacts, non-text plugins)
+SKIP_DIRS = {"search_backend_sqlite", "search_backend_sonic", "search_backend_ripgrep"}
+# Filename suffixes that are executor artifacts, not content
+EXECUTOR_ARTIFACT_SUFFIXES = (".stdout.log", ".stderr.log", ".pid", ".sh", ".meta.json")
 
 
 def get_text_size_kb(texts: list[str]) -> int:
@@ -80,32 +71,49 @@ def strip_html_tags(html: str) -> str:
 
 
 def find_indexable_content() -> list[tuple[str, str]]:
-    """Find text content to index from extractor outputs."""
+    """Auto-discover text content to index from all plugin output directories.
+
+    Walks every subdirectory of SNAP_DIR and collects .txt, .md, .html, .htm
+    files, stripping HTML tags where needed.  This avoids hardcoding which
+    plugins produce indexable output — any plugin that writes text files will
+    be picked up automatically.
+    """
     results = []
     snap_dir = SNAP_DIR
 
-    for extractor, file_pattern in INDEXABLE_FILES:
-        plugin_dir = snap_dir / extractor
-        if not plugin_dir.exists():
+    if not snap_dir.is_dir():
+        return results
+
+    for plugin_dir in sorted(snap_dir.iterdir()):
+        if not plugin_dir.is_dir():
             continue
 
-        if "*" in file_pattern:
-            matches = list(plugin_dir.glob(file_pattern))
-        else:
-            match = plugin_dir / file_pattern
-            matches = [match] if match.exists() else []
+        extractor = plugin_dir.name
+        if extractor in SKIP_DIRS:
+            continue
 
-        for match in matches:
-            if match.is_file() and match.stat().st_size > 0:
-                try:
-                    content = match.read_text(encoding="utf-8", errors="ignore")
-                    if content.strip():
-                        if match.suffix in (".html", ".htm"):
-                            content = strip_html_tags(content)
-                        rel_path = match.relative_to(plugin_dir)
-                        results.append((f"{extractor}/{rel_path.as_posix()}", content))
-                except Exception:
+        for match in plugin_dir.rglob("*"):
+            if not match.is_file():
+                continue
+            if match.suffix.lower() not in INDEXABLE_EXTENSIONS:
+                continue
+            if any(match.name.endswith(s) for s in EXECUTOR_ARTIFACT_SUFFIXES):
+                continue
+            if match.stat().st_size == 0:
+                continue
+
+            try:
+                content = match.read_text(encoding="utf-8", errors="ignore")
+                if not content.strip():
                     continue
+                if match.suffix.lower() in (".html", ".htm"):
+                    content = strip_html_tags(content)
+                if not content.strip():
+                    continue
+                rel_path = match.relative_to(plugin_dir)
+                results.append((f"{extractor}/{rel_path.as_posix()}", content))
+            except Exception:
+                continue
 
     return results
 

--- a/abx_plugins/plugins/search_backend_sonic/on_Snapshot__91_index_sonic.py
+++ b/abx_plugins/plugins/search_backend_sonic/on_Snapshot__91_index_sonic.py
@@ -92,28 +92,27 @@ def find_indexable_content() -> list[tuple[str, str]]:
         if extractor in SKIP_DIRS:
             continue
 
-        for match in plugin_dir.rglob("*"):
-            if not match.is_file():
-                continue
-            if match.suffix.lower() not in INDEXABLE_EXTENSIONS:
-                continue
-            if any(match.name.endswith(s) for s in EXECUTOR_ARTIFACT_SUFFIXES):
-                continue
-            if match.stat().st_size == 0:
-                continue
+        for ext in INDEXABLE_EXTENSIONS:
+            for match in plugin_dir.rglob(f"*{ext}"):
+                if not match.is_file():
+                    continue
+                if any(match.name.endswith(s) for s in EXECUTOR_ARTIFACT_SUFFIXES):
+                    continue
+                if match.stat().st_size == 0:
+                    continue
 
-            try:
-                content = match.read_text(encoding="utf-8", errors="ignore")
-                if not content.strip():
+                try:
+                    content = match.read_text(encoding="utf-8", errors="ignore")
+                    if not content.strip():
+                        continue
+                    if match.suffix.lower() in (".html", ".htm"):
+                        content = strip_html_tags(content)
+                    if not content.strip():
+                        continue
+                    rel_path = match.relative_to(plugin_dir)
+                    results.append((f"{extractor}/{rel_path.as_posix()}", content))
+                except Exception:
                     continue
-                if match.suffix.lower() in (".html", ".htm"):
-                    content = strip_html_tags(content)
-                if not content.strip():
-                    continue
-                rel_path = match.relative_to(plugin_dir)
-                results.append((f"{extractor}/{rel_path.as_posix()}", content))
-            except Exception:
-                continue
 
     return results
 

--- a/abx_plugins/plugins/search_backend_sqlite/on_Snapshot__90_index_sqlite.py
+++ b/abx_plugins/plugins/search_backend_sqlite/on_Snapshot__90_index_sqlite.py
@@ -38,21 +38,12 @@ SNAP_DIR = Path(os.environ.get("SNAP_DIR", ".")).resolve()
 OUTPUT_DIR = SNAP_DIR / PLUGIN_DIR
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 os.chdir(OUTPUT_DIR)
-# Text file patterns to index, in priority order
-INDEXABLE_FILES = [
-    ("readability", "content.txt"),
-    ("readability", "content.html"),
-    ("mercury", "content.txt"),
-    ("mercury", "content.html"),
-    ("opendataloader", "content.txt"),
-    ("opendataloader", "content.md"),
-    ("htmltotext", "output.txt"),
-    ("singlefile", "singlefile.html"),
-    ("dom", "output.html"),
-    ("wget", "**/*.html"),
-    ("wget", "**/*.htm"),
-    ("title", "title.txt"),
-]
+# File extensions eligible for full-text indexing
+INDEXABLE_EXTENSIONS = {".txt", ".md", ".html", ".htm"}
+# Directories to skip (search backends themselves, executor artifacts, non-text plugins)
+SKIP_DIRS = {"search_backend_sqlite", "search_backend_sonic", "search_backend_ripgrep"}
+# Filename suffixes that are executor artifacts, not content
+EXECUTOR_ARTIFACT_SUFFIXES = (".stdout.log", ".stderr.log", ".pid", ".sh", ".meta.json")
 
 
 def get_text_size_kb(texts: list[str]) -> int:
@@ -75,33 +66,49 @@ def strip_html_tags(html: str) -> str:
 
 
 def find_indexable_content() -> list[tuple[str, str, Path]]:
-    """Find text content to index from extractor outputs."""
+    """Auto-discover text content to index from all plugin output directories.
+
+    Walks every subdirectory of SNAP_DIR and collects .txt, .md, .html, .htm
+    files, stripping HTML tags where needed.  This avoids hardcoding which
+    plugins produce indexable output — any plugin that writes text files will
+    be picked up automatically.
+    """
     results = []
     snap_dir = SNAP_DIR
 
-    for extractor, file_pattern in INDEXABLE_FILES:
-        plugin_dir = snap_dir / extractor
-        if not plugin_dir.exists():
+    if not snap_dir.is_dir():
+        return results
+
+    for plugin_dir in sorted(snap_dir.iterdir()):
+        if not plugin_dir.is_dir():
             continue
 
-        if "*" in file_pattern:
-            matches = list(plugin_dir.glob(file_pattern))
-        else:
-            match = plugin_dir / file_pattern
-            matches = [match] if match.exists() else []
+        extractor = plugin_dir.name
+        if extractor in SKIP_DIRS:
+            continue
 
-        for match in matches:
-            if match.is_file() and match.stat().st_size > 0:
-                try:
-                    content = match.read_text(encoding="utf-8", errors="ignore")
-                    if content.strip():
-                        if match.suffix in (".html", ".htm"):
-                            content = strip_html_tags(content)
-                        if content.strip():
-                            rel_path = match.relative_to(plugin_dir)
-                            results.append((f"{extractor}/{rel_path.as_posix()}", content, match))
-                except Exception:
+        for match in plugin_dir.rglob("*"):
+            if not match.is_file():
+                continue
+            if match.suffix.lower() not in INDEXABLE_EXTENSIONS:
+                continue
+            if any(match.name.endswith(s) for s in EXECUTOR_ARTIFACT_SUFFIXES):
+                continue
+            if match.stat().st_size == 0:
+                continue
+
+            try:
+                content = match.read_text(encoding="utf-8", errors="ignore")
+                if not content.strip():
                     continue
+                if match.suffix.lower() in (".html", ".htm"):
+                    content = strip_html_tags(content)
+                if not content.strip():
+                    continue
+                rel_path = match.relative_to(plugin_dir)
+                results.append((f"{extractor}/{rel_path.as_posix()}", content, match))
+            except Exception:
+                continue
 
     return results
 

--- a/abx_plugins/plugins/search_backend_sqlite/on_Snapshot__90_index_sqlite.py
+++ b/abx_plugins/plugins/search_backend_sqlite/on_Snapshot__90_index_sqlite.py
@@ -44,6 +44,8 @@ INDEXABLE_FILES = [
     ("readability", "content.html"),
     ("mercury", "content.txt"),
     ("mercury", "content.html"),
+    ("opendataloader", "content.txt"),
+    ("opendataloader", "content.md"),
     ("htmltotext", "output.txt"),
     ("singlefile", "singlefile.html"),
     ("dom", "output.html"),

--- a/abx_plugins/plugins/search_backend_sqlite/on_Snapshot__90_index_sqlite.py
+++ b/abx_plugins/plugins/search_backend_sqlite/on_Snapshot__90_index_sqlite.py
@@ -87,28 +87,27 @@ def find_indexable_content() -> list[tuple[str, str, Path]]:
         if extractor in SKIP_DIRS:
             continue
 
-        for match in plugin_dir.rglob("*"):
-            if not match.is_file():
-                continue
-            if match.suffix.lower() not in INDEXABLE_EXTENSIONS:
-                continue
-            if any(match.name.endswith(s) for s in EXECUTOR_ARTIFACT_SUFFIXES):
-                continue
-            if match.stat().st_size == 0:
-                continue
+        for ext in INDEXABLE_EXTENSIONS:
+            for match in plugin_dir.rglob(f"*{ext}"):
+                if not match.is_file():
+                    continue
+                if any(match.name.endswith(s) for s in EXECUTOR_ARTIFACT_SUFFIXES):
+                    continue
+                if match.stat().st_size == 0:
+                    continue
 
-            try:
-                content = match.read_text(encoding="utf-8", errors="ignore")
-                if not content.strip():
+                try:
+                    content = match.read_text(encoding="utf-8", errors="ignore")
+                    if not content.strip():
+                        continue
+                    if match.suffix.lower() in (".html", ".htm"):
+                        content = strip_html_tags(content)
+                    if not content.strip():
+                        continue
+                    rel_path = match.relative_to(plugin_dir)
+                    results.append((f"{extractor}/{rel_path.as_posix()}", content, match))
+                except Exception:
                     continue
-                if match.suffix.lower() in (".html", ".htm"):
-                    content = strip_html_tags(content)
-                if not content.strip():
-                    continue
-                rel_path = match.relative_to(plugin_dir)
-                results.append((f"{extractor}/{rel_path.as_posix()}", content, match))
-            except Exception:
-                continue
 
     return results
 


### PR DESCRIPTION
## Summary
Adds a new opendataloader plugin that performs OCR extraction on PDFs and images using the opendataloader-pdf binary. The plugin discovers PDF and image files produced by other plugins (pdf, screenshot, responses, staticfile) and extracts structured text content, tables, and metadata.

## Key Changes

- **Main snapshot hook** (`on_Snapshot__60_opendataloader.py`): Implements OCR extraction workflow
  - Discovers PDF and image sources from sibling plugin output directories
  - Runs opendataloader-pdf with markdown and text format extraction
  - Combines outputs from multiple sources into unified content files
  - Generates metadata about extraction results
  - Supports configuration via environment variables for binary path, timeout, and custom arguments

- **Install hook** (`on_Crawl__42_opendataloader_install.finite.bg.py`): Declares opendataloader-pdf as a binary dependency
  - Configures pip installation of opendataloader-pdf
  - Respects OPENDATALOADER_ENABLED flag

- **Configuration schema** (`config.json`): Defines plugin settings
  - OPENDATALOADER_ENABLED: Toggle plugin on/off (default: true)
  - OPENDATALOADER_BINARY: Path to binary (default: "opendataloader-pdf")
  - OPENDATALOADER_TIMEOUT: Extraction timeout in seconds (default: 120)
  - OPENDATALOADER_ARGS: Default command-line arguments
  - OPENDATALOADER_ARGS_EXTRA: Additional arguments to append

- **Comprehensive test suite** (`test_opendataloader.py`): Integration tests covering
  - Hook script existence verification
  - Binary installation via install hooks
  - Real PDF OCR extraction from web sources
  - Image OCR extraction from responses plugin output
  - Configuration disable flag behavior
  - Graceful handling of missing sources

## Implementation Details

- Searches for PDF/image sources using glob patterns across multiple plugin output directories
- Runs opendataloader-pdf separately for markdown and text formats to maximize content extraction
- Combines multi-source outputs with clear source attribution comments
- Writes atomic output files (content.md, content.txt, metadata.json) to prevent partial writes
- Handles timeouts and extraction errors gracefully with stderr logging
- Uses uv script format for dependency management in hook scripts

https://claude.ai/code/session_01UotSDYwHe14BhjMrYRtJAW
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/archivebox/abx-plugins/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `opendataloader` plugin that extracts text from PDFs using `opendataloader-pdf`, writing `content.md`, `content.txt`, and `metadata.json`. Search backends now auto-index these and other text-like files; hybrid OCR with fallback handles scanned PDFs.

- **New Features**
  - Finds PDFs from `pdf`, `responses`, and `staticfile`; processes all; merges results into atomic `content.md`, `content.txt`, and `metadata.json`; emits `succeeded`/`noresults` (PDF-only).
  - Optional hybrid OCR via `OPENDATALOADER_FORCE_OCR` and `OPENDATALOADER_HYBRID_URL` (adds `--hybrid docling-fast`, with optional `--hybrid-url`).
  - SQLite and Sonic auto-index any `.txt/.md/.html/.htm` under `SNAP_DIR` (skips search backend dirs and executor artifacts).

- **Bug Fixes**
  - Emit `failed` when the OCR binary cannot be executed instead of `noresults`.
  - Fallback to standard extraction when hybrid (`OPENDATALOADER_FORCE_OCR`) yields no content; return `content.txt` if only text extraction succeeds.
  - Install hook skips pip when `OPENDATALOADER_BINARY` points to a valid binary.
  - Puppeteer: auto-escalate `--install-deps` to `sudo` when needed so Chrome system dependencies install without running tests as root; after `sudo` install, `chown` the cache back to the current user to prevent permission errors.

<sup>Written for commit 6594625b84c60c1ee03247f6c93c70b84cb14a7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

