### PR TITLE
Add anchor links and hash navigation to plugin gallery

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -375,16 +375,7 @@
         overflow-wrap: anywhere;
       }
 
-      .plugin-anchor {
-        color: inherit;
-        text-decoration: none;
-      }
 
-      .plugin-anchor:hover {
-        text-decoration: underline;
-        text-underline-offset: 0.15em;
-        text-decoration-thickness: 2px;
-      }
 
       .plugin-slug {
         color: var(--muted);
@@ -897,7 +888,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#ytdlp" class="plugin-anchor">yt-dlp</a></h2>
+                <h2>yt-dlp</h2>
               </div>
               <div class="plugin-slug"><code>ytdlp</code></div>
               <p class="plugin-summary-description">Download video and audio media with metadata, subtitles, thumbnails, and description sidecars.</p>
@@ -1139,7 +1130,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#gallerydl" class="plugin-anchor">gallery-dl</a></h2>
+                <h2>gallery-dl</h2>
               </div>
               <div class="plugin-slug"><code>gallerydl</code></div>
               <p class="plugin-summary-description">Download image and media galleries along with metadata sidecars from supported sites.</p>
@@ -1338,7 +1329,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#forumdl" class="plugin-anchor">forum-dl</a></h2>
+                <h2>forum-dl</h2>
               </div>
               <div class="plugin-slug"><code>forumdl</code></div>
               <p class="plugin-summary-description">Download forum threads and exports in JSONL, WARC, and mailbox-style archive formats.</p>
@@ -1522,7 +1513,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#git" class="plugin-anchor">Git</a></h2>
+                <h2>Git</h2>
               </div>
               <div class="plugin-slug"><code>git</code></div>
               <p class="plugin-summary-description">Clone git repositories from supported repository URLs into the snapshot output directory.</p>
@@ -1711,7 +1702,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#wget" class="plugin-anchor">wget</a></h2>
+                <h2>wget</h2>
               </div>
               <div class="plugin-slug"><code>wget</code></div>
               <p class="plugin-summary-description">Archive pages and their requisites with wget, optionally writing WARC captures.</p>
@@ -1942,7 +1933,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#archivedotorg" class="plugin-anchor">Archive.org</a></h2>
+                <h2>Archive.org</h2>
               </div>
               <div class="plugin-slug"><code>archivedotorg</code></div>
               <p class="plugin-summary-description">Submit URLs to the Internet Archive Wayback Machine and save the resulting archive link.</p>
@@ -2076,7 +2067,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#favicon" class="plugin-anchor">Favicon</a></h2>
+                <h2>Favicon</h2>
               </div>
               <div class="plugin-slug"><code>favicon</code></div>
               <p class="plugin-summary-description">Fetch and save the site favicon or touch icon.</p>
@@ -2210,7 +2201,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#modalcloser" class="plugin-anchor">Modal Closer</a></h2>
+                <h2>Modal Closer</h2>
               </div>
               <div class="plugin-slug"><code>modalcloser</code></div>
               <p class="plugin-summary-description">Automatically dismiss dialogs, cookie banners, and framework modals while the page is being archived.</p>
@@ -2343,7 +2334,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#consolelog" class="plugin-anchor">Console Log</a></h2>
+                <h2>Console Log</h2>
               </div>
               <div class="plugin-slug"><code>consolelog</code></div>
               <p class="plugin-summary-description">Capture browser console messages emitted while the page loads.</p>
@@ -2470,7 +2461,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#dns" class="plugin-anchor">DNS</a></h2>
+                <h2>DNS</h2>
               </div>
               <div class="plugin-slug"><code>dns</code></div>
               <p class="plugin-summary-description">Record DNS activity observed while loading the page in Chrome.</p>
@@ -2597,7 +2588,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#ssl" class="plugin-anchor">SSL</a></h2>
+                <h2>SSL</h2>
               </div>
               <div class="plugin-slug"><code>ssl</code></div>
               <p class="plugin-summary-description">Capture TLS certificate and connection metadata for the loaded page.</p>
@@ -2724,7 +2715,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#responses" class="plugin-anchor">Responses</a></h2>
+                <h2>Responses</h2>
               </div>
               <div class="plugin-slug"><code>responses</code></div>
               <p class="plugin-summary-description">Capture HTTP response metadata for requests made during page load.</p>
@@ -2857,7 +2848,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#redirects" class="plugin-anchor">Redirects</a></h2>
+                <h2>Redirects</h2>
               </div>
               <div class="plugin-slug"><code>redirects</code></div>
               <p class="plugin-summary-description">Capture the redirect chain encountered while loading the page.</p>
@@ -2984,7 +2975,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#staticfile" class="plugin-anchor">Static File</a></h2>
+                <h2>Static File</h2>
               </div>
               <div class="plugin-slug"><code>staticfile</code></div>
               <p class="plugin-summary-description">Detect and download static-file responses directly when a URL resolves to a non-HTML asset.</p>
@@ -3123,7 +3114,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#headers" class="plugin-anchor">Headers</a></h2>
+                <h2>Headers</h2>
               </div>
               <div class="plugin-slug"><code>headers</code></div>
               <p class="plugin-summary-description">Capture HTTP headers for the main document response.</p>
@@ -3250,7 +3241,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#chrome" class="plugin-anchor">Chrome</a></h2>
+                <h2>Chrome</h2>
               </div>
               <div class="plugin-slug"><code>chrome</code></div>
               <p class="plugin-summary-description">Launch and manage a shared Chromium session for browser-driven plugins.</p>
@@ -3681,7 +3672,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#seo" class="plugin-anchor">SEO</a></h2>
+                <h2>SEO</h2>
               </div>
               <div class="plugin-slug"><code>seo</code></div>
               <p class="plugin-summary-description">Capture SEO-related metadata such as meta tags and Open Graph fields.</p>
@@ -3807,7 +3798,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#accessibility" class="plugin-anchor">Accessibility</a></h2>
+                <h2>Accessibility</h2>
               </div>
               <div class="plugin-slug"><code>accessibility</code></div>
               <p class="plugin-summary-description">Capture the browser accessibility tree for the archived page.</p>
@@ -3933,7 +3924,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#infiniscroll" class="plugin-anchor">Infinite Scroll</a></h2>
+                <h2>Infinite Scroll</h2>
               </div>
               <div class="plugin-slug"><code>infiniscroll</code></div>
               <p class="plugin-summary-description">Expand infinite-scroll pages and load additional content before downstream capture plugins run.</p>
@@ -4105,7 +4096,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#claudechrome" class="plugin-anchor">Claude Chrome</a></h2>
+                <h2>Claude Chrome</h2>
               </div>
               <div class="plugin-slug"><code>claudechrome</code></div>
               <p class="plugin-summary-description">Use Claude computer-use to interact with pages in Chrome via CDP screenshots and the Anthropic API.</p>
@@ -4299,7 +4290,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#singlefile" class="plugin-anchor">SingleFile</a></h2>
+                <h2>SingleFile</h2>
               </div>
               <div class="plugin-slug"><code>singlefile</code></div>
               <p class="plugin-summary-description">Save a complete page as a single self-contained HTML file using the SingleFile extension or CLI.</p>
@@ -4550,7 +4541,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#screenshot" class="plugin-anchor">Screenshot</a></h2>
+                <h2>Screenshot</h2>
               </div>
               <div class="plugin-slug"><code>screenshot</code></div>
               <p class="plugin-summary-description">Capture a PNG screenshot of the rendered page.</p>
@@ -4689,7 +4680,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#pdf" class="plugin-anchor">PDF</a></h2>
+                <h2>PDF</h2>
               </div>
               <div class="plugin-slug"><code>pdf</code></div>
               <p class="plugin-summary-description">Render the current page to PDF using the shared Chrome session.</p>
@@ -4828,7 +4819,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#dom" class="plugin-anchor">DOM</a></h2>
+                <h2>DOM</h2>
               </div>
               <div class="plugin-slug"><code>dom</code></div>
               <p class="plugin-summary-description">Save the fully rendered DOM HTML from the live page.</p>
@@ -4955,7 +4946,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#title" class="plugin-anchor">Title</a></h2>
+                <h2>Title</h2>
               </div>
               <div class="plugin-slug"><code>title</code></div>
               <p class="plugin-summary-description">Capture the final document title from the rendered page.</p>
@@ -5081,7 +5072,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#readability" class="plugin-anchor">Readability</a></h2>
+                <h2>Readability</h2>
               </div>
               <div class="plugin-slug"><code>readability</code></div>
               <p class="plugin-summary-description">Extract article HTML, text, and metadata using Mozilla Readability.</p>
@@ -5254,7 +5245,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#defuddle" class="plugin-anchor">Defuddle</a></h2>
+                <h2>Defuddle</h2>
               </div>
               <div class="plugin-slug"><code>defuddle</code></div>
               <p class="plugin-summary-description">Extract cleaned article HTML, text, and metadata from archived HTML using Defuddle.</p>
@@ -5425,7 +5416,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#mercury" class="plugin-anchor">Mercury</a></h2>
+                <h2>Mercury</h2>
               </div>
               <div class="plugin-slug"><code>mercury</code></div>
               <p class="plugin-summary-description">Extract article HTML, text, and metadata using the Postlight Mercury parser.</p>
@@ -5598,7 +5589,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#claudecodeextract" class="plugin-anchor">Claude Code Extract</a></h2>
+                <h2>Claude Code Extract</h2>
               </div>
               <div class="plugin-slug"><code>claudecodeextract</code></div>
               <p class="plugin-summary-description">Use Claude Code to generate clean Markdown from snapshot extractor outputs.</p>
@@ -5758,7 +5749,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#htmltotext" class="plugin-anchor">HTML to Text</a></h2>
+                <h2>HTML to Text</h2>
               </div>
               <div class="plugin-slug"><code>htmltotext</code></div>
               <p class="plugin-summary-description">Convert archived HTML from other extractors into plain text for indexing and analysis.</p>
@@ -5880,7 +5871,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#trafilatura" class="plugin-anchor">Trafilatura</a></h2>
+                <h2>Trafilatura</h2>
               </div>
               <div class="plugin-slug"><code>trafilatura</code></div>
               <p class="plugin-summary-description">Extract article content from archived HTML into text, markdown, HTML, CSV, JSON, and XML formats.</p>
@@ -6098,7 +6089,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#opendataloader" class="plugin-anchor">OpenDataLoader</a></h2>
+                <h2>OpenDataLoader</h2>
               </div>
               <div class="plugin-slug"><code>opendataloader</code></div>
               <p class="plugin-summary-description">Extract structured text, tables, and metadata from PDFs using opendataloader-pdf. Supports OCR for scanned PDFs via hybrid backend.</p>
@@ -6294,7 +6285,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#liteparse" class="plugin-anchor">LiteParse</a></h2>
+                <h2>LiteParse</h2>
               </div>
               <div class="plugin-slug"><code>liteparse</code></div>
               <p class="plugin-summary-description">Extract text and metadata from PDFs and documents using LiteParse (by LlamaIndex). Supports OCR via Tesseract.js.</p>
@@ -6471,7 +6462,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#papersdl" class="plugin-anchor">papers-dl</a></h2>
+                <h2>papers-dl</h2>
               </div>
               <div class="plugin-slug"><code>papersdl</code></div>
               <p class="plugin-summary-description">Fetch downloadable academic papers from paper URLs and DOI targets.</p>
@@ -6645,7 +6636,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#parse_html_urls" class="plugin-anchor">Parse HTML URLs</a></h2>
+                <h2>Parse HTML URLs</h2>
               </div>
               <div class="plugin-slug"><code>parse_html_urls</code></div>
               <p class="plugin-summary-description">Parse HTML documents and emit discovered links as JSONL snapshot records.</p>
@@ -6756,7 +6747,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#parse_txt_urls" class="plugin-anchor">Parse Text URLs</a></h2>
+                <h2>Parse Text URLs</h2>
               </div>
               <div class="plugin-slug"><code>parse_txt_urls</code></div>
               <p class="plugin-summary-description">Parse plain text documents and emit discovered URLs as JSONL snapshot records.</p>
@@ -6867,7 +6858,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#parse_rss_urls" class="plugin-anchor">Parse RSS URLs</a></h2>
+                <h2>Parse RSS URLs</h2>
               </div>
               <div class="plugin-slug"><code>parse_rss_urls</code></div>
               <p class="plugin-summary-description">Parse RSS and Atom feeds and emit discovered entry URLs as JSONL snapshot records.</p>
@@ -6978,7 +6969,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#parse_netscape_urls" class="plugin-anchor">Parse Netscape URLs</a></h2>
+                <h2>Parse Netscape URLs</h2>
               </div>
               <div class="plugin-slug"><code>parse_netscape_urls</code></div>
               <p class="plugin-summary-description">Parse Netscape bookmark HTML exports and emit discovered URLs as JSONL snapshot records.</p>
@@ -7089,7 +7080,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#parse_jsonl_urls" class="plugin-anchor">Parse JSONL URLs</a></h2>
+                <h2>Parse JSONL URLs</h2>
               </div>
               <div class="plugin-slug"><code>parse_jsonl_urls</code></div>
               <p class="plugin-summary-description">Parse JSONL bookmark exports and emit discovered URLs as JSONL snapshot records.</p>
@@ -7200,7 +7191,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#parse_dom_outlinks" class="plugin-anchor">Parse DOM Outlinks</a></h2>
+                <h2>Parse DOM Outlinks</h2>
               </div>
               <div class="plugin-slug"><code>parse_dom_outlinks</code></div>
               <p class="plugin-summary-description">Extract crawlable links from the rendered DOM and emit them as JSONL records.</p>
@@ -7326,7 +7317,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#search_backend_sqlite" class="plugin-anchor">SQLite Search</a></h2>
+                <h2>SQLite Search</h2>
               </div>
               <div class="plugin-slug"><code>search_backend_sqlite</code></div>
               <p class="plugin-summary-description">Index archived snapshot content into a SQLite FTS database for local search.</p>
@@ -7457,7 +7448,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#search_backend_sonic" class="plugin-anchor">Sonic Search</a></h2>
+                <h2>Sonic Search</h2>
               </div>
               <div class="plugin-slug"><code>search_backend_sonic</code></div>
               <p class="plugin-summary-description">Index archived snapshot content into a Sonic search backend.</p>
@@ -7604,7 +7595,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#claudecodecleanup" class="plugin-anchor">Claude Code Cleanup</a></h2>
+                <h2>Claude Code Cleanup</h2>
               </div>
               <div class="plugin-slug"><code>claudecodecleanup</code></div>
               <p class="plugin-summary-description">Use Claude Code to deduplicate and clean up redundant snapshot extractor outputs.</p>
@@ -7764,7 +7755,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#hashes" class="plugin-anchor">Hashes</a></h2>
+                <h2>Hashes</h2>
               </div>
               <div class="plugin-slug"><code>hashes</code></div>
               <p class="plugin-summary-description">Generate a hash manifest for files produced in the snapshot directory.</p>
@@ -7886,7 +7877,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#npm" class="plugin-anchor">npm</a></h2>
+                <h2>npm</h2>
               </div>
               <div class="plugin-slug"><code>npm</code></div>
               <p class="plugin-summary-description">Install binaries from npm packages and expose Node module paths.</p>
@@ -8001,7 +7992,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#claudecode" class="plugin-anchor">Claude Code</a></h2>
+                <h2>Claude Code</h2>
               </div>
               <div class="plugin-slug"><code>claudecode</code></div>
               <p class="plugin-summary-description">Run Claude Code AI agent on snapshots to extract, analyze, or transform archived content.</p>
@@ -8167,7 +8158,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#search_backend_ripgrep" class="plugin-anchor">ripgrep Search</a></h2>
+                <h2>ripgrep Search</h2>
               </div>
               <div class="plugin-slug"><code>search_backend_ripgrep</code></div>
               <p class="plugin-summary-description">Search archived snapshot files directly with ripgrep instead of maintaining an index.</p>
@@ -8314,7 +8305,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#puppeteer" class="plugin-anchor">Puppeteer</a></h2>
+                <h2>Puppeteer</h2>
               </div>
               <div class="plugin-slug"><code>puppeteer</code></div>
               <p class="plugin-summary-description">Install and manage Chromium through the Puppeteer toolchain.</p>
@@ -8429,7 +8420,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#ublock" class="plugin-anchor">uBlock Origin</a></h2>
+                <h2>uBlock Origin</h2>
               </div>
               <div class="plugin-slug"><code>ublock</code></div>
               <p class="plugin-summary-description">Install the uBlock Origin extension to block ads, trackers, and other page clutter during archiving.</p>
@@ -8542,7 +8533,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#istilldontcareaboutcookies" class="plugin-anchor">I Still Don't Care About Cookies</a></h2>
+                <h2>I Still Don't Care About Cookies</h2>
               </div>
               <div class="plugin-slug"><code>istilldontcareaboutcookies</code></div>
               <p class="plugin-summary-description">Install the I Still Don't Care About Cookies extension to dismiss cookie banners during archiving.</p>
@@ -8655,7 +8646,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#twocaptcha" class="plugin-anchor">2Captcha</a></h2>
+                <h2>2Captcha</h2>
               </div>
               <div class="plugin-slug"><code>twocaptcha</code></div>
               <p class="plugin-summary-description">Install and configure the 2Captcha extension to solve CAPTCHAs during browser-based archiving.</p>
@@ -8834,7 +8825,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#pip" class="plugin-anchor">pip</a></h2>
+                <h2>pip</h2>
               </div>
               <div class="plugin-slug"><code>pip</code></div>
               <p class="plugin-summary-description">Install Python-based binaries into a managed virtual environment.</p>
@@ -8935,7 +8926,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#brew" class="plugin-anchor">Homebrew</a></h2>
+                <h2>Homebrew</h2>
               </div>
               <div class="plugin-slug"><code>brew</code></div>
               <p class="plugin-summary-description">Install binaries through the Homebrew package manager.</p>
@@ -9035,7 +9026,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#apt" class="plugin-anchor">APT</a></h2>
+                <h2>APT</h2>
               </div>
               <div class="plugin-slug"><code>apt</code></div>
               <p class="plugin-summary-description">Install binaries through the Debian and Ubuntu APT package manager.</p>
@@ -9135,7 +9126,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#custom" class="plugin-anchor">Custom</a></h2>
+                <h2>Custom</h2>
               </div>
               <div class="plugin-slug"><code>custom</code></div>
               <p class="plugin-summary-description">Install binaries using an arbitrary custom shell command.</p>
@@ -9230,7 +9221,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#env" class="plugin-anchor">Environment</a></h2>
+                <h2>Environment</h2>
               </div>
               <div class="plugin-slug"><code>env</code></div>
               <p class="plugin-summary-description">Discover binaries that are already available on the system PATH.</p>
@@ -9325,7 +9316,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#base" class="plugin-anchor">Base</a></h2>
+                <h2>Base</h2>
               </div>
               <div class="plugin-slug"><code>base</code></div>
               <p class="plugin-summary-description">Provide shared utilities, helpers, and test support used by other plugins.</p>
@@ -9396,7 +9387,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#media" class="plugin-anchor">Media</a></h2>
+                <h2>Media</h2>
               </div>
               <div class="plugin-slug"><code>media</code></div>
               <p class="plugin-summary-description">Provide a shared namespace for media-related plugin outputs and helpers.</p>
@@ -9653,7 +9644,7 @@
 
         <div class="footer-meta">
           <span>Generated from <a href="https://github.com/ArchiveBox/abx-plugins" target="_blank" rel="noreferrer">ArchiveBox/abx-plugins</a> at ref <code>main</code>.</span>
-          <span>Updated 2026-03-19 22:04 UTC</span>
+          <span>Updated 2026-03-19 22:08 UTC</span>
         </div>
       </footer>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -375,6 +375,17 @@
         overflow-wrap: anywhere;
       }
 
+      .plugin-anchor {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      .plugin-anchor:hover {
+        text-decoration: underline;
+        text-underline-offset: 0.15em;
+        text-decoration-thickness: 2px;
+      }
+
       .plugin-slug {
         color: var(--muted);
         font-size: 0.86rem;
@@ -879,13 +890,14 @@
 
       <main class="gallery" id="plugin-gallery">
         <details
+          id="ytdlp"
           class="plugin-card plugin-card--snapshot"
           data-search="ytdlp crawl snapshot yt-dlp download video and audio media with metadata, subtitles, thumbnails, and description sidecars. python snapshot embed fullscreen yt-dlp node ffmpeg audio/ video/ image/ application/x-subrip text/vtt application/json text/plain on_crawl__15_ytdlp_install.finite.bg.py on_snapshot__02_ytdlp.finite.bg.py ytdlp_enabled enable video/audio downloading with yt-dlp ytdlp_binary path to yt-dlp binary ytdlp_node_binary path to node.js binary for yt-dlp js runtime ytdlp_timeout timeout for yt-dlp downloads in seconds ytdlp_cookies_file path to cookies file ytdlp_max_size maximum file size for yt-dlp downloads ytdlp_check_ssl_validity whether to verify ssl certificates ytdlp_args default yt-dlp arguments ytdlp_args_extra extra arguments to append to yt-dlp command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>yt-dlp</h2>
+                <h2><a href="#ytdlp" class="plugin-anchor">yt-dlp</a></h2>
               </div>
               <div class="plugin-slug"><code>ytdlp</code></div>
               <p class="plugin-summary-description">Download video and audio media with metadata, subtitles, thumbnails, and description sidecars.</p>
@@ -1120,13 +1132,14 @@
           </div>
         </details>
         <details
+          id="gallerydl"
           class="plugin-card plugin-card--snapshot"
           data-search="gallerydl crawl snapshot gallery-dl download image and media galleries along with metadata sidecars from supported sites. python snapshot embed fullscreen gallery-dl image/ video/ application/json text/plain application/zip on_crawl__20_gallerydl_install.finite.bg.py on_snapshot__03_gallerydl.finite.bg.py gallerydl_enabled enable gallery downloading with gallery-dl gallerydl_binary path to gallery-dl binary gallerydl_timeout timeout for gallery downloads in seconds gallerydl_cookies_file path to cookies file gallerydl_check_ssl_validity whether to verify ssl certificates gallerydl_args default gallery-dl arguments gallerydl_args_extra extra arguments to append to gallery-dl command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>gallery-dl</h2>
+                <h2><a href="#gallerydl" class="plugin-anchor">gallery-dl</a></h2>
               </div>
               <div class="plugin-slug"><code>gallerydl</code></div>
               <p class="plugin-summary-description">Download image and media galleries along with metadata sidecars from supported sites.</p>
@@ -1318,13 +1331,14 @@
           </div>
         </details>
         <details
+          id="forumdl"
           class="plugin-card plugin-card--snapshot"
           data-search="forumdl crawl snapshot forum-dl download forum threads and exports in jsonl, warc, and mailbox-style archive formats. python snapshot embed fullscreen forum-dl application/x-ndjson application/warc message/rfc822 on_crawl__25_forumdl_install.finite.bg.py on_snapshot__04_forumdl.finite.bg.py forumdl_enabled enable forum downloading with forum-dl forumdl_binary path to forum-dl binary forumdl_timeout timeout for forum downloads in seconds forumdl_output_format output format for forum downloads forumdl_args default forum-dl arguments forumdl_args_extra extra arguments to append to forum-dl command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>forum-dl</h2>
+                <h2><a href="#forumdl" class="plugin-anchor">forum-dl</a></h2>
               </div>
               <div class="plugin-slug"><code>forumdl</code></div>
               <p class="plugin-summary-description">Download forum threads and exports in JSONL, WARC, and mailbox-style archive formats.</p>
@@ -1501,13 +1515,14 @@
           </div>
         </details>
         <details
+          id="git"
           class="plugin-card plugin-card--snapshot"
           data-search="git crawl snapshot git clone git repositories from supported repository urls into the snapshot output directory. python snapshot embed git text/ application/ image/ audio/ video/ font/ on_crawl__05_git_install.finite.bg.py on_snapshot__05_git.finite.bg.py git_enabled enable git repository cloning git_binary path to git binary git_timeout timeout for git operations in seconds git_domains comma-separated list of domains to treat as git repositories git_args default git arguments git_args_extra extra arguments to append to git command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Git</h2>
+                <h2><a href="#git" class="plugin-anchor">Git</a></h2>
               </div>
               <div class="plugin-slug"><code>git</code></div>
               <p class="plugin-summary-description">Clone git repositories from supported repository URLs into the snapshot output directory.</p>
@@ -1689,13 +1704,14 @@
           </div>
         </details>
         <details
+          id="wget"
           class="plugin-card plugin-card--snapshot"
           data-search="wget crawl snapshot wget archive pages and their requisites with wget, optionally writing warc captures. python snapshot embed wget text/html application/warc image/ text/css application/javascript font/ audio/ video/ on_crawl__10_wget_install.finite.bg.py on_snapshot__06_wget.finite.bg.py wget_enabled enable wget archiving wget_warc_enabled save warc archive file wget_binary path to wget binary wget_timeout timeout for wget in seconds wget_user_agent user agent string for wget wget_cookies_file path to cookies file wget_check_ssl_validity whether to verify ssl certificates wget_args default wget arguments wget_args_extra extra arguments to append to wget command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>wget</h2>
+                <h2><a href="#wget" class="plugin-anchor">wget</a></h2>
               </div>
               <div class="plugin-slug"><code>wget</code></div>
               <p class="plugin-summary-description">Archive pages and their requisites with wget, optionally writing WARC captures.</p>
@@ -1919,13 +1935,14 @@
           </div>
         </details>
         <details
+          id="archivedotorg"
           class="plugin-card plugin-card--snapshot"
           data-search="archivedotorg snapshot archive.org submit urls to the internet archive wayback machine and save the resulting archive link. python snapshot embed text/plain on_snapshot__08_archivedotorg.finite.bg.py archivedotorg_enabled submit urls to archive.org wayback machine archivedotorg_timeout timeout for archive.org submission in seconds archivedotorg_user_agent user agent string"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Archive.org</h2>
+                <h2><a href="#archivedotorg" class="plugin-anchor">Archive.org</a></h2>
               </div>
               <div class="plugin-slug"><code>archivedotorg</code></div>
               <p class="plugin-summary-description">Submit URLs to the Internet Archive Wayback Machine and save the resulting archive link.</p>
@@ -2052,13 +2069,14 @@
           </div>
         </details>
         <details
+          id="favicon"
           class="plugin-card plugin-card--snapshot"
           data-search="favicon snapshot favicon fetch and save the site favicon or touch icon. python snapshot embed image/ on_snapshot__11_favicon.finite.bg.py favicon_enabled enable favicon downloading favicon_timeout timeout for favicon fetch in seconds favicon_user_agent user agent string"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Favicon</h2>
+                <h2><a href="#favicon" class="plugin-anchor">Favicon</a></h2>
               </div>
               <div class="plugin-slug"><code>favicon</code></div>
               <p class="plugin-summary-description">Fetch and save the site favicon or touch icon.</p>
@@ -2185,13 +2203,14 @@
           </div>
         </details>
         <details
+          id="modalcloser"
           class="plugin-card plugin-card--snapshot"
           data-search="modalcloser snapshot modal closer automatically dismiss dialogs, cookie banners, and framework modals while the page is being archived. javascript snapshot chrome chrome on_snapshot__15_modalcloser.daemon.bg.js modalcloser_enabled enable automatic modal and dialog closing modalcloser_timeout delay before auto-closing dialogs (ms) modalcloser_poll_interval how often to check for css modals (ms)"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Modal Closer</h2>
+                <h2><a href="#modalcloser" class="plugin-anchor">Modal Closer</a></h2>
               </div>
               <div class="plugin-slug"><code>modalcloser</code></div>
               <p class="plugin-summary-description">Automatically dismiss dialogs, cookie banners, and framework modals while the page is being archived.</p>
@@ -2317,13 +2336,14 @@
           </div>
         </details>
         <details
+          id="consolelog"
           class="plugin-card plugin-card--snapshot"
           data-search="consolelog snapshot console log capture browser console messages emitted while the page loads. javascript snapshot chrome chrome application/x-ndjson on_snapshot__21_consolelog.daemon.bg.js consolelog_enabled enable console log capture consolelog_timeout timeout for console log capture in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Console Log</h2>
+                <h2><a href="#consolelog" class="plugin-anchor">Console Log</a></h2>
               </div>
               <div class="plugin-slug"><code>consolelog</code></div>
               <p class="plugin-summary-description">Capture browser console messages emitted while the page loads.</p>
@@ -2443,13 +2463,14 @@
           </div>
         </details>
         <details
+          id="dns"
           class="plugin-card plugin-card--snapshot"
           data-search="dns snapshot dns record dns activity observed while loading the page in chrome. javascript snapshot chrome chrome application/x-ndjson on_snapshot__22_dns.daemon.bg.js dns_enabled enable dns traffic recording during page load dns_timeout timeout for dns recording in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>DNS</h2>
+                <h2><a href="#dns" class="plugin-anchor">DNS</a></h2>
               </div>
               <div class="plugin-slug"><code>dns</code></div>
               <p class="plugin-summary-description">Record DNS activity observed while loading the page in Chrome.</p>
@@ -2569,13 +2590,14 @@
           </div>
         </details>
         <details
+          id="ssl"
           class="plugin-card plugin-card--snapshot"
           data-search="ssl snapshot ssl capture tls certificate and connection metadata for the loaded page. javascript snapshot chrome chrome application/x-ndjson on_snapshot__23_ssl.daemon.bg.js ssl_enabled enable ssl certificate capture ssl_timeout timeout for ssl capture in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>SSL</h2>
+                <h2><a href="#ssl" class="plugin-anchor">SSL</a></h2>
               </div>
               <div class="plugin-slug"><code>ssl</code></div>
               <p class="plugin-summary-description">Capture TLS certificate and connection metadata for the loaded page.</p>
@@ -2695,13 +2717,14 @@
           </div>
         </details>
         <details
+          id="responses"
           class="plugin-card plugin-card--snapshot"
           data-search="responses snapshot responses capture http response metadata for requests made during page load. javascript snapshot chrome chrome application/x-ndjson text/ image/ audio/ video/ application/ font/ on_snapshot__24_responses.daemon.bg.js responses_enabled enable http response capture responses_timeout timeout for response capture in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Responses</h2>
+                <h2><a href="#responses" class="plugin-anchor">Responses</a></h2>
               </div>
               <div class="plugin-slug"><code>responses</code></div>
               <p class="plugin-summary-description">Capture HTTP response metadata for requests made during page load.</p>
@@ -2827,13 +2850,14 @@
           </div>
         </details>
         <details
+          id="redirects"
           class="plugin-card plugin-card--snapshot"
           data-search="redirects snapshot redirects capture the redirect chain encountered while loading the page. javascript snapshot chrome chrome application/x-ndjson on_snapshot__25_redirects.daemon.bg.js redirects_enabled enable redirect chain capture redirects_timeout timeout for redirect capture in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Redirects</h2>
+                <h2><a href="#redirects" class="plugin-anchor">Redirects</a></h2>
               </div>
               <div class="plugin-slug"><code>redirects</code></div>
               <p class="plugin-summary-description">Capture the redirect chain encountered while loading the page.</p>
@@ -2953,13 +2977,14 @@
           </div>
         </details>
         <details
+          id="staticfile"
           class="plugin-card plugin-card--snapshot"
           data-search="staticfile snapshot static file detect and download static-file responses directly when a url resolves to a non-html asset. javascript snapshot embed chrome chrome application/pdf application/epub+zip image/ audio/ video/ application/json application/xml text/csv text/xml application/zip application/octet-stream application/x- on_snapshot__26_staticfile.daemon.bg.js staticfile_enabled enable static file detection staticfile_timeout timeout for static file detection in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Static File</h2>
+                <h2><a href="#staticfile" class="plugin-anchor">Static File</a></h2>
               </div>
               <div class="plugin-slug"><code>staticfile</code></div>
               <p class="plugin-summary-description">Detect and download static-file responses directly when a URL resolves to a non-HTML asset.</p>
@@ -3091,13 +3116,14 @@
           </div>
         </details>
         <details
+          id="headers"
           class="plugin-card plugin-card--snapshot"
           data-search="headers snapshot headers capture http headers for the main document response. javascript snapshot chrome chrome application/json on_snapshot__27_headers.daemon.bg.js headers_enabled enable http headers capture headers_timeout timeout for headers capture in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Headers</h2>
+                <h2><a href="#headers" class="plugin-anchor">Headers</a></h2>
               </div>
               <div class="plugin-slug"><code>headers</code></div>
               <p class="plugin-summary-description">Capture HTTP headers for the main document response.</p>
@@ -3217,13 +3243,14 @@
           </div>
         </details>
         <details
+          id="chrome"
           class="plugin-card plugin-card--snapshot"
           data-search="chrome crawl snapshot chrome launch and manage a shared chromium session for browser-driven plugins. javascript snapshot chrome text/plain application/json on_crawl__70_chrome_install.finite.bg.py on_crawl__90_chrome_launch.daemon.bg.js on_crawl__91_chrome_wait.js on_snapshot__09_chrome_launch.daemon.bg.js on_snapshot__10_chrome_tab.daemon.bg.js on_snapshot__11_chrome_wait.js on_snapshot__30_chrome_navigate.js chrome_enabled enable chromium browser integration for archiving chrome_binary path to chromium binary chrome_node_binary path to node.js binary (for puppeteer) chrome_timeout timeout for chrome operations in seconds chrome_headless run chrome in headless mode chrome_sandbox enable chrome sandbox (disable in docker with --no-sandbox) chrome_resolution browser viewport resolution (width,height) chrome_user_data_dir path to chrome user data directory for persistent sessions (derived from active_persona if not set) chrome_user_agent user agent string for chrome chrome_cdp_url connect to an already-running browser over cdp instead of launching a new local chromium process chrome_is_local whether the managed browser process is local and should have a live chrome.pid marker chrome_keepalive keep the browser alive after the owning crawl/snapshot hook exits instead of closing it during cleanup chrome_isolation whether chrome runs as one shared browser per crawl or a separate browser per snapshot chrome_args default chrome command-line arguments (static flags only, dynamic args like --user-data-dir are added at runtime) chrome_args_extra extra arguments to append to chrome command (for user customization) chrome_pageload_timeout timeout for page navigation/load in seconds chrome_wait_for page load completion condition (domcontentloaded, load, networkidle0, networkidle2) chrome_delay_after_load extra delay in seconds after page load completes before archiving (useful for js-heavy spas) chrome_check_ssl_validity whether to verify ssl certificates (disable for self-signed certs)"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Chrome</h2>
+                <h2><a href="#chrome" class="plugin-anchor">Chrome</a></h2>
               </div>
               <div class="plugin-slug"><code>chrome</code></div>
               <p class="plugin-summary-description">Launch and manage a shared Chromium session for browser-driven plugins.</p>
@@ -3647,13 +3674,14 @@
           </div>
         </details>
         <details
+          id="seo"
           class="plugin-card plugin-card--snapshot"
           data-search="seo snapshot seo capture seo-related metadata such as meta tags and open graph fields. javascript snapshot chrome chrome application/json on_snapshot__38_seo.js seo_enabled enable seo metadata capture seo_timeout timeout for seo capture in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>SEO</h2>
+                <h2><a href="#seo" class="plugin-anchor">SEO</a></h2>
               </div>
               <div class="plugin-slug"><code>seo</code></div>
               <p class="plugin-summary-description">Capture SEO-related metadata such as meta tags and Open Graph fields.</p>
@@ -3772,13 +3800,14 @@
           </div>
         </details>
         <details
+          id="accessibility"
           class="plugin-card plugin-card--snapshot"
           data-search="accessibility snapshot accessibility capture the browser accessibility tree for the archived page. javascript snapshot chrome chrome application/json on_snapshot__39_accessibility.js accessibility_enabled enable accessibility tree capture accessibility_timeout timeout for accessibility capture in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Accessibility</h2>
+                <h2><a href="#accessibility" class="plugin-anchor">Accessibility</a></h2>
               </div>
               <div class="plugin-slug"><code>accessibility</code></div>
               <p class="plugin-summary-description">Capture the browser accessibility tree for the archived page.</p>
@@ -3897,13 +3926,14 @@
           </div>
         </details>
         <details
+          id="infiniscroll"
           class="plugin-card plugin-card--snapshot"
           data-search="infiniscroll snapshot infinite scroll expand infinite-scroll pages and load additional content before downstream capture plugins run. javascript snapshot chrome chrome on_snapshot__45_infiniscroll.js infiniscroll_enabled enable infinite scroll page expansion infiniscroll_timeout maximum timeout for scrolling in seconds infiniscroll_scroll_delay delay between scrolls in milliseconds infiniscroll_scroll_distance distance to scroll per step in pixels infiniscroll_scroll_limit maximum number of scroll steps infiniscroll_min_height minimum page height to scroll to in pixels infiniscroll_expand_details expand <details> elements and click 'load more' buttons for comments"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Infinite Scroll</h2>
+                <h2><a href="#infiniscroll" class="plugin-anchor">Infinite Scroll</a></h2>
               </div>
               <div class="plugin-slug"><code>infiniscroll</code></div>
               <p class="plugin-summary-description">Expand infinite-scroll pages and load additional content before downstream capture plugins run.</p>
@@ -4068,13 +4098,14 @@
           </div>
         </details>
         <details
+          id="claudechrome"
           class="plugin-card plugin-card--snapshot"
           data-search="claudechrome crawl snapshot claude chrome use claude computer-use to interact with pages in chrome via cdp screenshots and the anthropic api. javascript snapshot embed fullscreen chrome node application/json image/png on_crawl__84_claudechrome_install.finite.bg.js on_crawl__96_claudechrome_config.js on_snapshot__47_claudechrome.js claudechrome_enabled enable claude for chrome browser extension for ai-driven page interaction claudechrome_prompt prompt for claude to execute on the page. claude can click buttons, fill forms, download files, and interact with any page element. claudechrome_timeout timeout for claude for chrome operations in seconds claudechrome_model claude model to use (e.g. sonnet, opus, haiku). availability depends on your plan. claudechrome_max_actions maximum number of agentic loop iterations (screenshots + actions) per page anthropic_api_key anthropic api key for claude for chrome authentication"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Claude Chrome</h2>
+                <h2><a href="#claudechrome" class="plugin-anchor">Claude Chrome</a></h2>
               </div>
               <div class="plugin-slug"><code>claudechrome</code></div>
               <p class="plugin-summary-description">Use Claude computer-use to interact with pages in Chrome via CDP screenshots and the Anthropic API.</p>
@@ -4261,13 +4292,14 @@
           </div>
         </details>
         <details
+          id="singlefile"
           class="plugin-card plugin-card--snapshot"
           data-search="singlefile crawl snapshot singlefile save a complete page as a single self-contained html file using the singlefile extension or cli. python snapshot embed chrome chrome single-file-cli text/html on_crawl__45_singlefile_install.finite.bg.py on_crawl__82_singlefile_install.finite.bg.js on_snapshot__50_singlefile.py singlefile_enabled enable singlefile archiving singlefile_binary path to single-file binary singlefile_node_binary path to node.js binary singlefile_chrome_binary path to chromium binary singlefile_timeout timeout for singlefile in seconds singlefile_user_agent user agent string singlefile_cookies_file path to cookies file singlefile_check_ssl_validity whether to verify ssl certificates singlefile_chrome_args chrome command-line arguments for singlefile singlefile_args default single-file arguments singlefile_args_extra extra arguments to append to single-file command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>SingleFile</h2>
+                <h2><a href="#singlefile" class="plugin-anchor">SingleFile</a></h2>
               </div>
               <div class="plugin-slug"><code>singlefile</code></div>
               <p class="plugin-summary-description">Save a complete page as a single self-contained HTML file using the SingleFile extension or CLI.</p>
@@ -4511,13 +4543,14 @@
           </div>
         </details>
         <details
+          id="screenshot"
           class="plugin-card plugin-card--snapshot"
           data-search="screenshot snapshot screenshot capture a png screenshot of the rendered page. javascript snapshot embed fullscreen chrome chrome image/png on_snapshot__51_screenshot.js screenshot_enabled enable screenshot capture screenshot_timeout timeout for screenshot capture in seconds screenshot_resolution screenshot resolution (width,height)"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Screenshot</h2>
+                <h2><a href="#screenshot" class="plugin-anchor">Screenshot</a></h2>
               </div>
               <div class="plugin-slug"><code>screenshot</code></div>
               <p class="plugin-summary-description">Capture a PNG screenshot of the rendered page.</p>
@@ -4649,13 +4682,14 @@
           </div>
         </details>
         <details
+          id="pdf"
           class="plugin-card plugin-card--snapshot"
           data-search="pdf snapshot pdf render the current page to pdf using the shared chrome session. javascript snapshot embed fullscreen chrome chrome application/pdf on_snapshot__52_pdf.js pdf_enabled enable pdf generation pdf_timeout timeout for pdf generation in seconds pdf_resolution pdf page resolution (width,height)"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>PDF</h2>
+                <h2><a href="#pdf" class="plugin-anchor">PDF</a></h2>
               </div>
               <div class="plugin-slug"><code>pdf</code></div>
               <p class="plugin-summary-description">Render the current page to PDF using the shared Chrome session.</p>
@@ -4787,13 +4821,14 @@
           </div>
         </details>
         <details
+          id="dom"
           class="plugin-card plugin-card--snapshot"
           data-search="dom snapshot dom save the fully rendered dom html from the live page. javascript snapshot embed chrome chrome text/html on_snapshot__53_dom.js dom_enabled enable dom capture dom_timeout timeout for dom capture in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>DOM</h2>
+                <h2><a href="#dom" class="plugin-anchor">DOM</a></h2>
               </div>
               <div class="plugin-slug"><code>dom</code></div>
               <p class="plugin-summary-description">Save the fully rendered DOM HTML from the live page.</p>
@@ -4913,13 +4948,14 @@
           </div>
         </details>
         <details
+          id="title"
           class="plugin-card plugin-card--snapshot"
           data-search="title snapshot title capture the final document title from the rendered page. javascript snapshot chrome chrome text/plain on_snapshot__54_title.js title_enabled enable title extraction title_timeout timeout for title extraction in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Title</h2>
+                <h2><a href="#title" class="plugin-anchor">Title</a></h2>
               </div>
               <div class="plugin-slug"><code>title</code></div>
               <p class="plugin-summary-description">Capture the final document title from the rendered page.</p>
@@ -5038,13 +5074,14 @@
           </div>
         </details>
         <details
+          id="readability"
           class="plugin-card plugin-card--snapshot"
           data-search="readability crawl snapshot readability extract article html, text, and metadata using mozilla readability. python snapshot embed fullscreen readability-extractor text/html text/plain application/json on_crawl__35_readability_install.finite.bg.py on_snapshot__56_readability.py readability_enabled enable readability text extraction readability_binary path to readability-extractor binary readability_timeout timeout for readability in seconds readability_args default readability arguments readability_args_extra extra arguments to append to readability command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Readability</h2>
+                <h2><a href="#readability" class="plugin-anchor">Readability</a></h2>
               </div>
               <div class="plugin-slug"><code>readability</code></div>
               <p class="plugin-summary-description">Extract article HTML, text, and metadata using Mozilla Readability.</p>
@@ -5210,13 +5247,14 @@
           </div>
         </details>
         <details
+          id="defuddle"
           class="plugin-card plugin-card--snapshot"
           data-search="defuddle crawl snapshot defuddle extract cleaned article html, text, and metadata from archived html using defuddle. python snapshot defuddle text/html text/plain application/json on_crawl__41_defuddle_install.finite.bg.py on_snapshot__57_defuddle.py defuddle_enabled enable defuddle text extraction defuddle_binary path to defuddle binary defuddle_timeout timeout for defuddle in seconds defuddle_args default defuddle arguments defuddle_args_extra extra arguments to append to defuddle command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Defuddle</h2>
+                <h2><a href="#defuddle" class="plugin-anchor">Defuddle</a></h2>
               </div>
               <div class="plugin-slug"><code>defuddle</code></div>
               <p class="plugin-summary-description">Extract cleaned article HTML, text, and metadata from archived HTML using Defuddle.</p>
@@ -5380,13 +5418,14 @@
           </div>
         </details>
         <details
+          id="mercury"
           class="plugin-card plugin-card--snapshot"
           data-search="mercury crawl snapshot mercury extract article html, text, and metadata using the postlight mercury parser. python snapshot embed postlight-parser text/html text/plain application/json on_crawl__40_mercury_install.finite.bg.py on_snapshot__57_mercury.py mercury_enabled enable mercury text extraction mercury_binary path to mercury/postlight parser binary mercury_timeout timeout for mercury in seconds mercury_args default mercury parser arguments mercury_args_extra extra arguments to append to mercury parser command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Mercury</h2>
+                <h2><a href="#mercury" class="plugin-anchor">Mercury</a></h2>
               </div>
               <div class="plugin-slug"><code>mercury</code></div>
               <p class="plugin-summary-description">Extract article HTML, text, and metadata using the Postlight Mercury parser.</p>
@@ -5552,13 +5591,14 @@
           </div>
         </details>
         <details
+          id="claudecodeextract"
           class="plugin-card plugin-card--snapshot"
           data-search="claudecodeextract snapshot claude code extract use claude code to generate clean markdown from snapshot extractor outputs. python snapshot embed fullscreen claudecode claude text/markdown on_snapshot__58_claudecodeextract.py claudecodeextract_enabled enable claude code ai extraction claudecodeextract_timeout timeout for claude code extraction in seconds claudecodeextract_prompt custom prompt for claude code extraction. use this to define what claude should extract or generate from the snapshot. claudecodeextract_model claude model to use for extraction (e.g. sonnet, opus, haiku) claudecodeextract_max_turns maximum number of agentic turns for extraction"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Claude Code Extract</h2>
+                <h2><a href="#claudecodeextract" class="plugin-anchor">Claude Code Extract</a></h2>
               </div>
               <div class="plugin-slug"><code>claudecodeextract</code></div>
               <p class="plugin-summary-description">Use Claude Code to generate clean Markdown from snapshot extractor outputs.</p>
@@ -5711,13 +5751,14 @@
           </div>
         </details>
         <details
+          id="htmltotext"
           class="plugin-card plugin-card--snapshot"
           data-search="htmltotext snapshot html to text convert archived html from other extractors into plain text for indexing and analysis. python snapshot text/plain on_snapshot__58_htmltotext.py htmltotext_enabled enable html to text conversion htmltotext_timeout timeout for html to text conversion in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>HTML to Text</h2>
+                <h2><a href="#htmltotext" class="plugin-anchor">HTML to Text</a></h2>
               </div>
               <div class="plugin-slug"><code>htmltotext</code></div>
               <p class="plugin-summary-description">Convert archived HTML from other extractors into plain text for indexing and analysis.</p>
@@ -5832,13 +5873,14 @@
           </div>
         </details>
         <details
+          id="trafilatura"
           class="plugin-card plugin-card--snapshot"
           data-search="trafilatura crawl snapshot trafilatura extract article content from archived html into text, markdown, html, csv, json, and xml formats. python snapshot trafilatura text/plain text/markdown text/html text/csv application/json application/xml application/tei+xml on_crawl__41_trafilatura_install.finite.bg.py on_snapshot__59_trafilatura.py trafilatura_enabled enable trafilatura extraction trafilatura_binary path to trafilatura binary trafilatura_timeout timeout for trafilatura in seconds trafilatura_output_txt write plain text output (content.txt) trafilatura_output_markdown write markdown output (content.md) trafilatura_output_html write html output (content.html) trafilatura_output_csv write csv output (content.csv) trafilatura_output_json write json output (content.json) trafilatura_output_xml write xml output (content.xml) trafilatura_output_xmltei write xml tei output (content.xmltei)"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Trafilatura</h2>
+                <h2><a href="#trafilatura" class="plugin-anchor">Trafilatura</a></h2>
               </div>
               <div class="plugin-slug"><code>trafilatura</code></div>
               <p class="plugin-summary-description">Extract article content from archived HTML into text, markdown, HTML, CSV, JSON, and XML formats.</p>
@@ -6049,13 +6091,14 @@
           </div>
         </details>
         <details
+          id="opendataloader"
           class="plugin-card plugin-card--snapshot"
           data-search="opendataloader crawl snapshot opendataloader extract structured text, tables, and metadata from pdfs using opendataloader-pdf. supports ocr for scanned pdfs via hybrid backend. python snapshot opendataloader-pdf text/plain text/markdown application/json on_crawl__42_opendataloader_install.finite.bg.py on_snapshot__60_opendataloader.py opendataloader_enabled enable pdf text extraction with opendataloader-pdf opendataloader_binary path to opendataloader-pdf binary opendataloader_timeout timeout for pdf extraction in seconds opendataloader_force_ocr use hybrid ocr backend (--hybrid docling-fast) for scanned/image-based pdfs. requires opendataloader-pdf-hybrid server running. opendataloader_hybrid_url url of the opendataloader-pdf-hybrid server (e.g. http://localhost:5002). if empty, uses the default built-in url. opendataloader_args default opendataloader-pdf arguments opendataloader_args_extra extra arguments to append to opendataloader-pdf command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>OpenDataLoader</h2>
+                <h2><a href="#opendataloader" class="plugin-anchor">OpenDataLoader</a></h2>
               </div>
               <div class="plugin-slug"><code>opendataloader</code></div>
               <p class="plugin-summary-description">Extract structured text, tables, and metadata from PDFs using opendataloader-pdf. Supports OCR for scanned PDFs via hybrid backend.</p>
@@ -6244,13 +6287,14 @@
           </div>
         </details>
         <details
+          id="liteparse"
           class="plugin-card plugin-card--snapshot"
           data-search="liteparse crawl snapshot liteparse extract text and metadata from pdfs and documents using liteparse (by llamaindex). supports ocr via tesseract.js. python snapshot lit text/plain application/json on_crawl__43_liteparse_install.finite.bg.py on_snapshot__61_liteparse.py liteparse_enabled enable liteparse document extraction liteparse_binary path to lit binary liteparse_timeout timeout for liteparse extraction in seconds liteparse_args default liteparse arguments liteparse_args_extra extra arguments to append to liteparse command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>LiteParse</h2>
+                <h2><a href="#liteparse" class="plugin-anchor">LiteParse</a></h2>
               </div>
               <div class="plugin-slug"><code>liteparse</code></div>
               <p class="plugin-summary-description">Extract text and metadata from PDFs and documents using LiteParse (by LlamaIndex). Supports OCR via Tesseract.js.</p>
@@ -6420,13 +6464,14 @@
           </div>
         </details>
         <details
+          id="papersdl"
           class="plugin-card plugin-card--snapshot"
           data-search="papersdl crawl snapshot papers-dl fetch downloadable academic papers from paper urls and doi targets. python snapshot embed fullscreen papers-dl application/pdf on_crawl__30_papersdl_install.finite.bg.py on_snapshot__66_papersdl.finite.bg.py papersdl_enabled enable paper downloading with papers-dl papersdl_binary path to papers-dl binary papersdl_timeout timeout for paper downloads in seconds papersdl_args default papers-dl arguments papersdl_args_extra extra arguments to append to papers-dl command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>papers-dl</h2>
+                <h2><a href="#papersdl" class="plugin-anchor">papers-dl</a></h2>
               </div>
               <div class="plugin-slug"><code>papersdl</code></div>
               <p class="plugin-summary-description">Fetch downloadable academic papers from paper URLs and DOI targets.</p>
@@ -6593,13 +6638,14 @@
           </div>
         </details>
         <details
+          id="parse_html_urls"
           class="plugin-card plugin-card--snapshot"
           data-search="parse_html_urls snapshot parse html urls parse html documents and emit discovered links as jsonl snapshot records. python snapshot application/x-ndjson on_snapshot__70_parse_html_urls.py parse_html_urls_enabled enable html url parsing"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Parse HTML URLs</h2>
+                <h2><a href="#parse_html_urls" class="plugin-anchor">Parse HTML URLs</a></h2>
               </div>
               <div class="plugin-slug"><code>parse_html_urls</code></div>
               <p class="plugin-summary-description">Parse HTML documents and emit discovered links as JSONL snapshot records.</p>
@@ -6703,13 +6749,14 @@
           </div>
         </details>
         <details
+          id="parse_txt_urls"
           class="plugin-card plugin-card--snapshot"
           data-search="parse_txt_urls snapshot parse text urls parse plain text documents and emit discovered urls as jsonl snapshot records. python snapshot application/x-ndjson on_snapshot__71_parse_txt_urls.py parse_txt_urls_enabled enable plain text url parsing"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Parse Text URLs</h2>
+                <h2><a href="#parse_txt_urls" class="plugin-anchor">Parse Text URLs</a></h2>
               </div>
               <div class="plugin-slug"><code>parse_txt_urls</code></div>
               <p class="plugin-summary-description">Parse plain text documents and emit discovered URLs as JSONL snapshot records.</p>
@@ -6813,13 +6860,14 @@
           </div>
         </details>
         <details
+          id="parse_rss_urls"
           class="plugin-card plugin-card--snapshot"
           data-search="parse_rss_urls snapshot parse rss urls parse rss and atom feeds and emit discovered entry urls as jsonl snapshot records. python snapshot application/x-ndjson on_snapshot__72_parse_rss_urls.py parse_rss_urls_enabled enable rss/atom feed url parsing"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Parse RSS URLs</h2>
+                <h2><a href="#parse_rss_urls" class="plugin-anchor">Parse RSS URLs</a></h2>
               </div>
               <div class="plugin-slug"><code>parse_rss_urls</code></div>
               <p class="plugin-summary-description">Parse RSS and Atom feeds and emit discovered entry URLs as JSONL snapshot records.</p>
@@ -6923,13 +6971,14 @@
           </div>
         </details>
         <details
+          id="parse_netscape_urls"
           class="plugin-card plugin-card--snapshot"
           data-search="parse_netscape_urls snapshot parse netscape urls parse netscape bookmark html exports and emit discovered urls as jsonl snapshot records. python snapshot application/x-ndjson on_snapshot__73_parse_netscape_urls.py parse_netscape_urls_enabled enable netscape bookmarks html url parsing"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Parse Netscape URLs</h2>
+                <h2><a href="#parse_netscape_urls" class="plugin-anchor">Parse Netscape URLs</a></h2>
               </div>
               <div class="plugin-slug"><code>parse_netscape_urls</code></div>
               <p class="plugin-summary-description">Parse Netscape bookmark HTML exports and emit discovered URLs as JSONL snapshot records.</p>
@@ -7033,13 +7082,14 @@
           </div>
         </details>
         <details
+          id="parse_jsonl_urls"
           class="plugin-card plugin-card--snapshot"
           data-search="parse_jsonl_urls snapshot parse jsonl urls parse jsonl bookmark exports and emit discovered urls as jsonl snapshot records. python snapshot application/x-ndjson on_snapshot__74_parse_jsonl_urls.py parse_jsonl_urls_enabled enable json lines url parsing"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Parse JSONL URLs</h2>
+                <h2><a href="#parse_jsonl_urls" class="plugin-anchor">Parse JSONL URLs</a></h2>
               </div>
               <div class="plugin-slug"><code>parse_jsonl_urls</code></div>
               <p class="plugin-summary-description">Parse JSONL bookmark exports and emit discovered URLs as JSONL snapshot records.</p>
@@ -7143,13 +7193,14 @@
           </div>
         </details>
         <details
+          id="parse_dom_outlinks"
           class="plugin-card plugin-card--snapshot"
           data-search="parse_dom_outlinks snapshot parse dom outlinks extract crawlable links from the rendered dom and emit them as jsonl records. javascript snapshot chrome chrome application/x-ndjson on_snapshot__75_parse_dom_outlinks.js parse_dom_outlinks_enabled enable dom outlinks parsing from archived pages parse_dom_outlinks_timeout timeout for dom outlinks parsing in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Parse DOM Outlinks</h2>
+                <h2><a href="#parse_dom_outlinks" class="plugin-anchor">Parse DOM Outlinks</a></h2>
               </div>
               <div class="plugin-slug"><code>parse_dom_outlinks</code></div>
               <p class="plugin-summary-description">Extract crawlable links from the rendered DOM and emit them as JSONL records.</p>
@@ -7268,13 +7319,14 @@
           </div>
         </details>
         <details
+          id="search_backend_sqlite"
           class="plugin-card plugin-card--snapshot"
           data-search="search_backend_sqlite snapshot sqlite search index archived snapshot content into a sqlite fts database for local search. python snapshot application/vnd.sqlite3 on_snapshot__90_index_sqlite.py search_backend_sqlite_db sqlite fts database filename search_backend_sqlite_separate_database use separate database file for fts index search_backend_sqlite_tokenizers fts5 tokenizer configuration"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>SQLite Search</h2>
+                <h2><a href="#search_backend_sqlite" class="plugin-anchor">SQLite Search</a></h2>
               </div>
               <div class="plugin-slug"><code>search_backend_sqlite</code></div>
               <p class="plugin-summary-description">Index archived snapshot content into a SQLite FTS database for local search.</p>
@@ -7398,13 +7450,14 @@
           </div>
         </details>
         <details
+          id="search_backend_sonic"
           class="plugin-card plugin-card--snapshot"
           data-search="search_backend_sonic snapshot sonic search index archived snapshot content into a sonic search backend. python snapshot on_snapshot__91_index_sonic.py search_backend_sonic_host_name sonic server hostname search_backend_sonic_port sonic server port search_backend_sonic_password sonic server password search_backend_sonic_collection sonic collection name search_backend_sonic_bucket sonic bucket name"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Sonic Search</h2>
+                <h2><a href="#search_backend_sonic" class="plugin-anchor">Sonic Search</a></h2>
               </div>
               <div class="plugin-slug"><code>search_backend_sonic</code></div>
               <p class="plugin-summary-description">Index archived snapshot content into a Sonic search backend.</p>
@@ -7544,13 +7597,14 @@
           </div>
         </details>
         <details
+          id="claudecodecleanup"
           class="plugin-card plugin-card--snapshot"
           data-search="claudecodecleanup snapshot claude code cleanup use claude code to deduplicate and clean up redundant snapshot extractor outputs. python snapshot embed fullscreen claudecode claude text/plain on_snapshot__92_claudecodecleanup.py claudecodecleanup_enabled enable claude code ai cleanup of snapshot files claudecodecleanup_timeout timeout for claude code cleanup in seconds claudecodecleanup_prompt custom prompt for claude code cleanup. defines what claude should clean up and how to determine which duplicates to keep. claudecodecleanup_model claude model to use for cleanup (e.g. sonnet, opus, haiku) claudecodecleanup_max_turns maximum number of agentic turns for cleanup"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Claude Code Cleanup</h2>
+                <h2><a href="#claudecodecleanup" class="plugin-anchor">Claude Code Cleanup</a></h2>
               </div>
               <div class="plugin-slug"><code>claudecodecleanup</code></div>
               <p class="plugin-summary-description">Use Claude Code to deduplicate and clean up redundant snapshot extractor outputs.</p>
@@ -7703,13 +7757,14 @@
           </div>
         </details>
         <details
+          id="hashes"
           class="plugin-card plugin-card--snapshot"
           data-search="hashes snapshot hashes generate a hash manifest for files produced in the snapshot directory. python snapshot application/json on_snapshot__93_hashes.py hashes_enabled enable merkle tree hash generation hashes_timeout timeout for merkle tree generation in seconds"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Hashes</h2>
+                <h2><a href="#hashes" class="plugin-anchor">Hashes</a></h2>
               </div>
               <div class="plugin-slug"><code>hashes</code></div>
               <p class="plugin-summary-description">Generate a hash manifest for files produced in the snapshot directory.</p>
@@ -7824,13 +7879,14 @@
           </div>
         </details>
         <details
+          id="npm"
           class="plugin-card"
           data-search="npm crawl binary npm install binaries from npm packages and expose node module paths. python crawl node npm on_binary__10_npm_install.py on_crawl__00_npm_install.py"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>npm</h2>
+                <h2><a href="#npm" class="plugin-anchor">npm</a></h2>
               </div>
               <div class="plugin-slug"><code>npm</code></div>
               <p class="plugin-summary-description">Install binaries from npm packages and expose Node module paths.</p>
@@ -7938,13 +7994,14 @@
           </div>
         </details>
         <details
+          id="claudecode"
           class="plugin-card plugin-card--crawl-only"
           data-search="claudecode crawl claude code run claude code ai agent on snapshots to extract, analyze, or transform archived content. python crawl embed fullscreen node claude application/json on_crawl__35_claudecode_install.finite.bg.py claudecode_enabled enable claude code ai agent integration. controls the crawl-time claude binary install hook; child plugins still need the claudecode plugin installed and a working claude binary. claudecode_binary path to claude code cli binary claudecode_timeout timeout for claude code operations in seconds anthropic_api_key anthropic api key for claude code authentication claudecode_model claude model to use (e.g. sonnet, opus, haiku) claudecode_max_turns maximum number of agentic turns per invocation"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Claude Code</h2>
+                <h2><a href="#claudecode" class="plugin-anchor">Claude Code</a></h2>
               </div>
               <div class="plugin-slug"><code>claudecode</code></div>
               <p class="plugin-summary-description">Run Claude Code AI agent on snapshots to extract, analyze, or transform archived content.</p>
@@ -8103,13 +8160,14 @@
           </div>
         </details>
         <details
+          id="search_backend_ripgrep"
           class="plugin-card plugin-card--crawl-only"
           data-search="search_backend_ripgrep crawl ripgrep search search archived snapshot files directly with ripgrep instead of maintaining an index. python crawl ripgrep on_crawl__50_ripgrep_install.finite.bg.py ripgrep_binary path to ripgrep binary ripgrep_timeout search timeout in seconds ripgrep_args default ripgrep arguments ripgrep_args_extra extra arguments to append to ripgrep command"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>ripgrep Search</h2>
+                <h2><a href="#search_backend_ripgrep" class="plugin-anchor">ripgrep Search</a></h2>
               </div>
               <div class="plugin-slug"><code>search_backend_ripgrep</code></div>
               <p class="plugin-summary-description">Search archived snapshot files directly with ripgrep instead of maintaining an index.</p>
@@ -8249,13 +8307,14 @@
           </div>
         </details>
         <details
+          id="puppeteer"
           class="plugin-card"
           data-search="puppeteer crawl binary puppeteer install and manage chromium through the puppeteer toolchain. python crawl puppeteer chrome on_binary__12_puppeteer_install.py on_crawl__60_puppeteer_install.py"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Puppeteer</h2>
+                <h2><a href="#puppeteer" class="plugin-anchor">Puppeteer</a></h2>
               </div>
               <div class="plugin-slug"><code>puppeteer</code></div>
               <p class="plugin-summary-description">Install and manage Chromium through the Puppeteer toolchain.</p>
@@ -8363,13 +8422,14 @@
           </div>
         </details>
         <details
+          id="ublock"
           class="plugin-card plugin-card--crawl-only"
           data-search="ublock crawl ublock origin install the ublock origin extension to block ads, trackers, and other page clutter during archiving. javascript crawl chrome chrome on_crawl__80_install_ublock_extension.finite.bg.js ublock_enabled enable ublock origin browser extension for ad blocking"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>uBlock Origin</h2>
+                <h2><a href="#ublock" class="plugin-anchor">uBlock Origin</a></h2>
               </div>
               <div class="plugin-slug"><code>ublock</code></div>
               <p class="plugin-summary-description">Install the uBlock Origin extension to block ads, trackers, and other page clutter during archiving.</p>
@@ -8475,13 +8535,14 @@
           </div>
         </details>
         <details
+          id="istilldontcareaboutcookies"
           class="plugin-card plugin-card--crawl-only"
           data-search="istilldontcareaboutcookies crawl i still don't care about cookies install the i still don't care about cookies extension to dismiss cookie banners during archiving. javascript crawl chrome chrome on_crawl__81_install_istilldontcareaboutcookies_extension.finite.bg.js istilldontcareaboutcookies_enabled enable i still don't care about cookies browser extension"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>I Still Don't Care About Cookies</h2>
+                <h2><a href="#istilldontcareaboutcookies" class="plugin-anchor">I Still Don't Care About Cookies</a></h2>
               </div>
               <div class="plugin-slug"><code>istilldontcareaboutcookies</code></div>
               <p class="plugin-summary-description">Install the I Still Don't Care About Cookies extension to dismiss cookie banners during archiving.</p>
@@ -8587,13 +8648,14 @@
           </div>
         </details>
         <details
+          id="twocaptcha"
           class="plugin-card plugin-card--crawl-only"
           data-search="twocaptcha crawl 2captcha install and configure the 2captcha extension to solve captchas during browser-based archiving. javascript crawl chrome chrome on_crawl__83_twocaptcha_install.finite.bg.js on_crawl__95_twocaptcha_config.js twocaptcha_enabled enable 2captcha browser extension for automatic captcha solving twocaptcha_api_key 2captcha api key for captcha solving service (get from https://2captcha.com) twocaptcha_retry_count number of times to retry captcha solving on error twocaptcha_retry_delay delay in seconds between captcha solving retries twocaptcha_timeout timeout for captcha solving in seconds twocaptcha_auto_submit automatically submit forms after captcha is solved"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>2Captcha</h2>
+                <h2><a href="#twocaptcha" class="plugin-anchor">2Captcha</a></h2>
               </div>
               <div class="plugin-slug"><code>twocaptcha</code></div>
               <p class="plugin-summary-description">Install and configure the 2Captcha extension to solve CAPTCHAs during browser-based archiving.</p>
@@ -8765,13 +8827,14 @@
           </div>
         </details>
         <details
+          id="pip"
           class="plugin-card plugin-card--binary-only"
           data-search="pip binary pip install python-based binaries into a managed virtual environment. python binary python pip on_binary__11_pip_install.py"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>pip</h2>
+                <h2><a href="#pip" class="plugin-anchor">pip</a></h2>
               </div>
               <div class="plugin-slug"><code>pip</code></div>
               <p class="plugin-summary-description">Install Python-based binaries into a managed virtual environment.</p>
@@ -8865,13 +8928,14 @@
           </div>
         </details>
         <details
+          id="brew"
           class="plugin-card plugin-card--binary-only"
           data-search="brew binary homebrew install binaries through the homebrew package manager. python binary brew on_binary__12_brew_install.py"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Homebrew</h2>
+                <h2><a href="#brew" class="plugin-anchor">Homebrew</a></h2>
               </div>
               <div class="plugin-slug"><code>brew</code></div>
               <p class="plugin-summary-description">Install binaries through the Homebrew package manager.</p>
@@ -8964,13 +9028,14 @@
           </div>
         </details>
         <details
+          id="apt"
           class="plugin-card plugin-card--binary-only"
           data-search="apt binary apt install binaries through the debian and ubuntu apt package manager. python binary apt on_binary__13_apt_install.py"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>APT</h2>
+                <h2><a href="#apt" class="plugin-anchor">APT</a></h2>
               </div>
               <div class="plugin-slug"><code>apt</code></div>
               <p class="plugin-summary-description">Install binaries through the Debian and Ubuntu APT package manager.</p>
@@ -9063,13 +9128,14 @@
           </div>
         </details>
         <details
+          id="custom"
           class="plugin-card plugin-card--binary-only"
           data-search="custom binary custom install binaries using an arbitrary custom shell command. python binary on_binary__14_custom_install.py"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Custom</h2>
+                <h2><a href="#custom" class="plugin-anchor">Custom</a></h2>
               </div>
               <div class="plugin-slug"><code>custom</code></div>
               <p class="plugin-summary-description">Install binaries using an arbitrary custom shell command.</p>
@@ -9157,13 +9223,14 @@
           </div>
         </details>
         <details
+          id="env"
           class="plugin-card plugin-card--binary-only"
           data-search="env binary environment discover binaries that are already available on the system path. python binary on_binary__15_env_discover.py"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Environment</h2>
+                <h2><a href="#env" class="plugin-anchor">Environment</a></h2>
               </div>
               <div class="plugin-slug"><code>env</code></div>
               <p class="plugin-summary-description">Discover binaries that are already available on the system PATH.</p>
@@ -9251,13 +9318,14 @@
           </div>
         </details>
         <details
+          id="base"
           class="plugin-card"
           data-search="base base provide shared utilities, helpers, and test support used by other plugins."
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Base</h2>
+                <h2><a href="#base" class="plugin-anchor">Base</a></h2>
               </div>
               <div class="plugin-slug"><code>base</code></div>
               <p class="plugin-summary-description">Provide shared utilities, helpers, and test support used by other plugins.</p>
@@ -9321,13 +9389,14 @@
           </div>
         </details>
         <details
+          id="media"
           class="plugin-card"
           data-search="media media provide a shared namespace for media-related plugin outputs and helpers."
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>Media</h2>
+                <h2><a href="#media" class="plugin-anchor">Media</a></h2>
               </div>
               <div class="plugin-slug"><code>media</code></div>
               <p class="plugin-summary-description">Provide a shared namespace for media-related plugin outputs and helpers.</p>
@@ -9584,7 +9653,7 @@
 
         <div class="footer-meta">
           <span>Generated from <a href="https://github.com/ArchiveBox/abx-plugins" target="_blank" rel="noreferrer">ArchiveBox/abx-plugins</a> at ref <code>main</code>.</span>
-          <span>Updated 2026-03-19 21:47 UTC</span>
+          <span>Updated 2026-03-19 22:04 UTC</span>
         </div>
       </footer>
     </div>
@@ -9610,7 +9679,36 @@
         emptyState.hidden = count !== 0;
       };
 
-      searchInput.addEventListener("input", applyFilter);
+      const setHash = (value) => {
+        const clean = value.replace(/^#/, "").trim();
+        if (clean) {
+          history.replaceState(null, "", "#" + clean);
+        } else {
+          history.replaceState(null, "", location.pathname + location.search);
+        }
+      };
+
+      const navigateToHash = () => {
+        const hash = decodeURIComponent(location.hash.replace(/^#/, "")).trim();
+        if (!hash) return;
+
+        const target = document.getElementById(hash);
+        if (target && target.classList.contains("plugin-card")) {
+          searchInput.value = "";
+          applyFilter();
+          target.open = true;
+          target.scrollIntoView({ behavior: "smooth", block: "start" });
+        } else {
+          searchInput.value = hash;
+          applyFilter();
+          searchInput.focus();
+        }
+      };
+
+      searchInput.addEventListener("input", () => {
+        applyFilter();
+        setHash(searchInput.value.trim());
+      });
 
       for (const card of cards) {
         card.addEventListener("click", (event) => {
@@ -9618,9 +9716,17 @@
           if (event.target.closest(interactiveSelector)) return;
           card.open = true;
         });
+
+        card.addEventListener("toggle", () => {
+          if (card.open) {
+            setHash(card.id);
+          }
+        });
       }
 
       applyFilter();
+      navigateToHash();
+      window.addEventListener("hashchange", navigateToHash);
     </script>
   </body>
 </html>

--- a/docs/index.html.j2
+++ b/docs/index.html.j2
@@ -375,6 +375,17 @@
         overflow-wrap: anywhere;
       }
 
+      .plugin-anchor {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      .plugin-anchor:hover {
+        text-decoration: underline;
+        text-underline-offset: 0.15em;
+        text-decoration-thickness: 2px;
+      }
+
       .plugin-slug {
         color: var(--muted);
         font-size: 0.86rem;
@@ -880,13 +891,14 @@
       <main class="gallery" id="plugin-gallery">
         {% for plugin in site.plugins %}
         <details
+          id="{{ plugin.name }}"
           class="plugin-card{% if 'Snapshot' in plugin.phases %} plugin-card--snapshot{% elif plugin.phases == ['Crawl'] %} plugin-card--crawl-only{% elif plugin.phases == ['Binary'] %} plugin-card--binary-only{% endif %}"
           data-search="{{ plugin.search_text }}"
         >
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2>{{ plugin.display_title }}</h2>
+                <h2><a href="#{{ plugin.name }}" class="plugin-anchor">{{ plugin.display_title }}</a></h2>
               </div>
               <div class="plugin-slug"><code>{{ plugin.name }}</code></div>
               {% if plugin.description %}
@@ -1299,7 +1311,36 @@
         emptyState.hidden = count !== 0;
       };
 
-      searchInput.addEventListener("input", applyFilter);
+      const setHash = (value) => {
+        const clean = value.replace(/^#/, "").trim();
+        if (clean) {
+          history.replaceState(null, "", "#" + clean);
+        } else {
+          history.replaceState(null, "", location.pathname + location.search);
+        }
+      };
+
+      const navigateToHash = () => {
+        const hash = decodeURIComponent(location.hash.replace(/^#/, "")).trim();
+        if (!hash) return;
+
+        const target = document.getElementById(hash);
+        if (target && target.classList.contains("plugin-card")) {
+          searchInput.value = "";
+          applyFilter();
+          target.open = true;
+          target.scrollIntoView({ behavior: "smooth", block: "start" });
+        } else {
+          searchInput.value = hash;
+          applyFilter();
+          searchInput.focus();
+        }
+      };
+
+      searchInput.addEventListener("input", () => {
+        applyFilter();
+        setHash(searchInput.value.trim());
+      });
 
       for (const card of cards) {
         card.addEventListener("click", (event) => {
@@ -1307,9 +1348,17 @@
           if (event.target.closest(interactiveSelector)) return;
           card.open = true;
         });
+
+        card.addEventListener("toggle", () => {
+          if (card.open) {
+            setHash(card.id);
+          }
+        });
       }
 
       applyFilter();
+      navigateToHash();
+      window.addEventListener("hashchange", navigateToHash);
     </script>
   </body>
 </html>

--- a/docs/index.html.j2
+++ b/docs/index.html.j2
@@ -375,16 +375,7 @@
         overflow-wrap: anywhere;
       }
 
-      .plugin-anchor {
-        color: inherit;
-        text-decoration: none;
-      }
 
-      .plugin-anchor:hover {
-        text-decoration: underline;
-        text-underline-offset: 0.15em;
-        text-decoration-thickness: 2px;
-      }
 
       .plugin-slug {
         color: var(--muted);
@@ -898,7 +889,7 @@
           <summary>
             <div class="plugin-main">
               <div class="plugin-title-row">
-                <h2><a href="#{{ plugin.name }}" class="plugin-anchor">{{ plugin.display_title }}</a></h2>
+                <h2>{{ plugin.display_title }}</h2>
               </div>
               <div class="plugin-slug"><code>{{ plugin.name }}</code></div>
               {% if plugin.description %}


### PR DESCRIPTION
## Summary
This PR adds anchor link support to the plugin gallery, allowing users to link directly to specific plugins and navigate to them via URL hash fragments.

## Key Changes
- **Anchor styling**: Added `.plugin-anchor` CSS class with hover underline effect for plugin title links
- **Plugin IDs**: Added `id` attribute to each plugin card using the plugin's slug name (e.g., `id="ytdlp"`)
- **Clickable titles**: Wrapped plugin display titles in anchor tags that link to their respective plugin IDs
- **Hash navigation**: Implemented JavaScript functions to:
  - Update URL hash when searching or opening plugin cards
  - Navigate to plugins when hash changes (via direct links or browser back/forward)
  - Auto-open plugin cards when accessed via hash
  - Scroll smoothly to the target plugin
- **Search integration**: Search input now updates the URL hash, allowing users to share search queries

## Implementation Details
- The `setHash()` function manages URL history updates without full page reloads
- The `navigateToHash()` function handles both direct plugin navigation (opens the card) and search-based navigation (filters gallery)
- Hash changes are handled via the `hashchange` event listener for browser navigation support
- Plugin cards emit `toggle` events to update the hash when manually opened/closed
- The implementation preserves existing search functionality while adding hash-based navigation

https://claude.ai/code/session_013iGTroMjCqyeRLMAkwXJ1z
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/archivebox/abx-plugins/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add deep links and hash navigation to the plugin gallery. You can link to a specific plugin or share a search, with smooth scroll and back/forward support.

- **New Features**
  - Each plugin card has an id matching its name (e.g., `ytdlp`).
  - The card’s id is the anchor target; no visible title links.
  - On load or hash change, `#<name>` opens and scrolls to the card; otherwise the hash becomes the search query.
  - Typing in search updates the URL hash; expanding a card updates the hash to its id.
  - Uses `history.replaceState` and `hashchange` for smooth navigation without reloads.

<sup>Written for commit 4fcecf70a8bd57057cca7d7703ab65f28dfba178. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

