### PR TITLE
Use dynamic user agent instead of hardcoded Chrome version

### DIFF
--- a/abx_plugins/plugins/istilldontcareaboutcookies/tests/test_istilldontcareaboutcookies.py
+++ b/abx_plugins/plugins/istilldontcareaboutcookies/tests/test_istilldontcareaboutcookies.py
@@ -413,7 +413,9 @@ const chromeUtils = require('{CHROME_UTILS_JS}');
         {{ puppeteer, browserWSEndpoint: '{cdp_url}' }},
         async (browser) => {{
             const page = await browser.newPage();
-            await page.setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36');
+            const browserUa = await browser.userAgent();
+            const realisticUa = browserUa.replace('HeadlessChrome/', 'Chrome/').replace(' Headless', '');
+            await page.setUserAgent(realisticUa);
             await page.setViewport({{ width: 1440, height: 900 }});
 
             console.error('Navigating to {test_url}...');

--- a/abx_plugins/plugins/modalcloser/tests/test_modalcloser.py
+++ b/abx_plugins/plugins/modalcloser/tests/test_modalcloser.py
@@ -562,8 +562,11 @@ async function main() {
     });
 
     const page = await browser.newPage();
-    // Set real user agent to bypass headless detection
-    await page.setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36');
+    // Set a non-headless UA derived from the actual browser to bypass headless detection
+    // without baking a Chrome version into source that will go stale on upgrade.
+    const browserUa = await browser.userAgent();
+    const realisticUa = browserUa.replace('HeadlessChrome/', 'Chrome/').replace(' Headless', '');
+    await page.setUserAgent(realisticUa);
     await page.setViewport({ width: 1440, height: 900 });
 
     console.error('Navigating to filmin.es...');

--- a/abx_plugins/plugins/ublock/tests/test_ublock.py
+++ b/abx_plugins/plugins/ublock/tests/test_ublock.py
@@ -333,7 +333,9 @@ const chromeUtils = require('{CHROME_UTILS_JS}');
         {{ puppeteer, browserWSEndpoint: '{cdp_url}' }},
         async (browser) => {{
             const page = await browser.newPage();
-            await page.setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36');
+            const browserUa = await browser.userAgent();
+            const realisticUa = browserUa.replace('HeadlessChrome/', 'Chrome/').replace(' Headless', '');
+            await page.setUserAgent(realisticUa);
             await page.setViewport({{ width: 1440, height: 900 }});
 
             // Track network requests


### PR DESCRIPTION
## Summary
Replace hardcoded user agent strings with dynamically generated ones derived from the actual browser instance. This prevents the user agent from becoming stale when the browser version is upgraded.

## Key Changes
- Modified three test files to generate realistic user agents dynamically instead of using a hardcoded Chrome 120.0.0.0 string:
  - `abx_plugins/plugins/modalcloser/tests/test_modalcloser.py`
  - `abx_plugins/plugins/istilldontcareaboutcookies/tests/test_istilldontcareaboutcookies.py`
  - `abx_plugins/plugins/ublock/tests/test_ublock.py`

## Implementation Details
- Retrieve the browser's default user agent using `browser.userAgent()`
- Transform it to appear non-headless by:
  - Replacing `'HeadlessChrome/'` with `'Chrome/'`
  - Removing the `' Headless'` suffix
- This approach bypasses headless detection while remaining version-agnostic, eliminating the need to update hardcoded version strings during browser upgrades

https://claude.ai/code/session_01Qrpaidw2umKZjG5zGQZrkv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a dynamic user agent in test fixtures instead of a hardcoded Chrome/120 string to avoid stale UAs after browser upgrades and keep the headless-bypass working. We read `browser.userAgent()`, replace `HeadlessChrome/` with `Chrome/`, remove the ` Headless` suffix, then call `page.setUserAgent()` in tests for `modalcloser`, `istilldontcareaboutcookies`, and `ublock`.

<sup>Written for commit c281077b635f03c5846d1274159e60c557525adf. Summary will update on new commits. <a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/28?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

