### PR TITLE
Fix ArchiveWebPage concurrent collection handoff

### DIFF
--- a/abx_plugins/plugins/archivewebpage/awp_internal.js
+++ b/abx_plugins/plugins/archivewebpage/awp_internal.js
@@ -173,6 +173,31 @@ function pickChromeSessionDir(candidates) {
   return null;
 }
 
+/**
+ * Return the collection id from the message AWP sends after newColl.
+ *
+ * Keep this small selector shared with the real-browser regression test: the
+ * popup port can already contain other collections messages by the time the
+ * newColl response arrives.
+ */
+function resolveCreatedCollectionId(
+  message,
+  collectionTitle,
+  existingCollectionIds = []
+) {
+  if (message?.type !== "collections" || !Array.isArray(message.collections)) {
+    return null;
+  }
+  const existingIds = new Set(existingCollectionIds);
+  const created = message.collections.find(
+    (collection) =>
+      collection?.title === collectionTitle &&
+      collection.id &&
+      !existingIds.has(collection.id)
+  );
+  return created?.id || null;
+}
+
 module.exports = {
   EXTENSION_NAME,
   resolveAwpExtension,
@@ -180,4 +205,5 @@ module.exports = {
   openAwpHelperTab,
   resolveChromeDirs,
   pickChromeSessionDir,
+  resolveCreatedCollectionId,
 };

--- a/abx_plugins/plugins/archivewebpage/on_Snapshot__16_archivewebpage_start.js
+++ b/abx_plugins/plugins/archivewebpage/on_Snapshot__16_archivewebpage_start.js
@@ -45,6 +45,7 @@ const {
   openAwpHelperTab,
   resolveChromeDirs,
   pickChromeSessionDir,
+  resolveCreatedCollectionId,
 } = require("./awp_internal.js");
 
 const hookConfig = loadConfig();
@@ -66,6 +67,14 @@ async function runStartHandshake(
   const { autorun, collectionTitle, timeoutMs } = options;
   const helperPage = await openAwpHelperTab(browser, extensionId, timeoutMs);
   try {
+    // Puppeteer cannot serialize a Node closure into evaluate(). Expose the
+    // shared selector as a page binding so production and the real-browser
+    // regression execute exactly the same implementation.
+    await helperPage.exposeFunction(
+      "__abxResolveCreatedCollectionId",
+      (message, title, existingCollectionIds) =>
+        resolveCreatedCollectionId(message, title, existingCollectionIds)
+    );
     const result = await helperPage.evaluate(
       async ({ tabId, url, autorun, collectionTitle, timeoutMs }) => {
         let handshakeStage = "connect";
@@ -117,26 +126,6 @@ async function runStartHandshake(
               });
             }
 
-            function resolveCreatedCollectionId(
-              message,
-              collectionTitle,
-              existingCollectionIds = new Set()
-            ) {
-              if (
-                message?.type !== "collections" ||
-                !Array.isArray(message.collections)
-              ) {
-                return null;
-              }
-              const created = message.collections.find(
-                (collection) =>
-                  collection?.title === collectionTitle &&
-                  collection.id &&
-                  !existingCollectionIds.has(collection.id)
-              );
-              return created?.id || null;
-            }
-
             async function startRecording(collId, requireExactCollection = false) {
               port.postMessage({
                 type: "startRecording",
@@ -175,22 +164,18 @@ async function runStartHandshake(
             // alone is global/default state and does not identify this reply.
             port.postMessage({ type: "newColl", title: collectionTitle });
             handshakeStage = "new collection";
-            const created = await waitFor(
-              (message) =>
-                Boolean(
-                  resolveCreatedCollectionId(
-                    message,
-                    collectionTitle,
-                    existingCollectionIds
-                  )
-                ),
-              "new collection"
-            );
-            const collId = resolveCreatedCollectionId(
-              created,
-              collectionTitle,
-              existingCollectionIds
-            );
+            let collId = null;
+            while (!collId) {
+              const collectionsMessage = await waitFor(
+                (message) => message?.type === "collections",
+                "new collection"
+              );
+              collId = await globalThis.__abxResolveCreatedCollectionId(
+                collectionsMessage,
+                collectionTitle,
+                [...existingCollectionIds]
+              );
+            }
             if (!collId) {
               throw new Error("AWP did not return a collection id");
             }
@@ -323,7 +308,7 @@ async function main() {
           "ARCHIVEWEBPAGE_COLLECTION_TITLE",
           "abx-dl"
         )} - ${url} [${
-          args.snapshotId || path.basename(path.dirname(outputDir))
+          args.snapshot_id || path.basename(path.dirname(outputDir))
         }/${crypto.randomUUID()}]`,
         timeoutMs: overallTimeoutMs,
       }

--- a/abx_plugins/plugins/archivewebpage/on_Snapshot__16_archivewebpage_start.js
+++ b/abx_plugins/plugins/archivewebpage/on_Snapshot__16_archivewebpage_start.js
@@ -85,29 +85,51 @@ async function runStartHandshake(
             const port = document.querySelector("wr-popup-viewer")?.port;
             if (!port) throw new Error("AWP popup port is not ready");
             const recvQueue = [];
-            port.onMessage.addListener((msg) => recvQueue.push(msg));
+            const waiters = [];
+            port.onMessage.addListener((message) => {
+              const waiterIndex = waiters.findIndex(({ predicate }) =>
+                predicate(message)
+              );
+              if (waiterIndex === -1) {
+                recvQueue.push(message);
+                return;
+              }
+              const [waiter] = waiters.splice(waiterIndex, 1);
+              clearTimeout(waiter.timeout);
+              waiter.resolve(message);
+            });
 
             function waitFor(predicate, label, ms = 2500) {
               return new Promise((resolve, reject) => {
-                while (recvQueue.length) {
-                  const msg = recvQueue.shift();
-                  if (predicate(msg)) {
-                    resolve(msg);
-                    return;
-                  }
+                const queuedIndex = recvQueue.findIndex(predicate);
+                if (queuedIndex !== -1) {
+                  resolve(recvQueue.splice(queuedIndex, 1)[0]);
+                  return;
                 }
-                const onMsg = (msg) => {
-                  if (predicate(msg)) {
-                    port.onMessage.removeListener(onMsg);
-                    resolve(msg);
-                  }
-                };
-                port.onMessage.addListener(onMsg);
-                setTimeout(() => {
-                  port.onMessage.removeListener(onMsg);
+                const waiter = { predicate, resolve, timeout: null };
+                waiter.timeout = setTimeout(() => {
+                  const waiterIndex = waiters.indexOf(waiter);
+                  if (waiterIndex !== -1) waiters.splice(waiterIndex, 1);
                   reject(new Error(`timed out waiting for ${label}`));
                 }, ms);
+                waiters.push(waiter);
               });
+            }
+
+            async function startRecording(collId) {
+              port.postMessage({
+                type: "startRecording",
+                collId,
+                url,
+                autorun: !!autorun,
+              });
+              return await waitFor(
+                (message) =>
+                  message?.type === "status" &&
+                  (message.recording === true || Boolean(message.failureMsg)),
+                "recording status",
+                timeoutMs
+              );
             }
 
             port.postMessage({ type: "startUpdates", tabId });
@@ -128,21 +150,36 @@ async function runStartHandshake(
               throw new Error("AWP did not return a collection id");
             }
 
-            port.postMessage({
-              type: "startRecording",
-              collId,
-              url,
-              autorun: !!autorun,
-            });
-
             handshakeStage = "recording status";
-            const status = await waitFor(
-              (message) =>
-                message?.type === "status" &&
-                (message.recording === true || Boolean(message.failureMsg)),
-              "recording status",
-              timeoutMs
-            );
+            let status = await startRecording(collId);
+
+            // AWP intentionally lets child tabs inherit their opener's active
+            // recorder. Starting an already-recording tab does not change its
+            // collection, so detach only this tab before assigning the fresh
+            // snapshot collection. Other tab recorders stay active.
+            if (
+              status.recording === true &&
+              status.collId &&
+              status.collId !== collId
+            ) {
+              handshakeStage = "inherited recorder stop";
+              port.postMessage({ type: "stopRecording" });
+              await waitFor(
+                (message) =>
+                  message?.type === "status" &&
+                  message.recording === false,
+                "inherited recorder stop",
+                timeoutMs
+              );
+              handshakeStage = "recording restart";
+              status = await startRecording(collId);
+            }
+
+            if (status.recording === true && status.collId !== collId) {
+              throw new Error(
+                `AWP recorder collection mismatch: expected ${collId}, got ${status.collId || "none"}`
+              );
+            }
 
             return { collId, status };
           })(),
@@ -252,6 +289,11 @@ async function main() {
     }
     if (handshake.status?.recording !== true) {
       throw new Error("AWP recorder did not confirm recording=true");
+    }
+    if (handshake.status?.collId !== handshake.collId) {
+      throw new Error(
+        `AWP recorder collection mismatch: expected ${handshake.collId}, got ${handshake.status?.collId || "none"}`
+      );
     }
 
     writeFileAtomic(

--- a/abx_plugins/plugins/archivewebpage/on_Snapshot__16_archivewebpage_start.js
+++ b/abx_plugins/plugins/archivewebpage/on_Snapshot__16_archivewebpage_start.js
@@ -116,7 +116,7 @@ async function runStartHandshake(
               });
             }
 
-            async function startRecording(collId) {
+            async function startRecording(collId, requireExactCollection = false) {
               port.postMessage({
                 type: "startRecording",
                 collId,
@@ -126,7 +126,9 @@ async function runStartHandshake(
               return await waitFor(
                 (message) =>
                   message?.type === "status" &&
-                  (message.recording === true || Boolean(message.failureMsg)),
+                  (Boolean(message.failureMsg) ||
+                    (message.recording === true &&
+                      (!requireExactCollection || message.collId === collId))),
                 "recording status",
                 timeoutMs
               );
@@ -172,7 +174,7 @@ async function runStartHandshake(
                 timeoutMs
               );
               handshakeStage = "recording restart";
-              status = await startRecording(collId);
+              status = await startRecording(collId, true);
             }
 
             if (status.recording === true && status.collId !== collId) {

--- a/abx_plugins/plugins/archivewebpage/on_Snapshot__16_archivewebpage_start.js
+++ b/abx_plugins/plugins/archivewebpage/on_Snapshot__16_archivewebpage_start.js
@@ -23,6 +23,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const crypto = require("crypto");
 
 const {
   ensureNodeModuleResolution,
@@ -116,6 +117,26 @@ async function runStartHandshake(
               });
             }
 
+            function resolveCreatedCollectionId(
+              message,
+              collectionTitle,
+              existingCollectionIds = new Set()
+            ) {
+              if (
+                message?.type !== "collections" ||
+                !Array.isArray(message.collections)
+              ) {
+                return null;
+              }
+              const created = message.collections.find(
+                (collection) =>
+                  collection?.title === collectionTitle &&
+                  collection.id &&
+                  !existingCollectionIds.has(collection.id)
+              );
+              return created?.id || null;
+            }
+
             async function startRecording(collId, requireExactCollection = false) {
               port.postMessage({
                 type: "startRecording",
@@ -136,18 +157,40 @@ async function runStartHandshake(
 
             port.postMessage({ type: "startUpdates", tabId });
             handshakeStage = "collections";
-            await waitFor((m) => m && m.type === "collections", "collections");
+            const collectionsBefore = await waitFor(
+              (message) => message?.type === "collections",
+              "collections"
+            );
+            const existingCollectionIds = new Set(
+              (collectionsBefore.collections || []).map(
+                (collection) => collection.id
+              )
+            );
 
             // Always create a fresh collection per snapshot so the resulting
-            // WACZ contains only requests from this archive run and not every
-            // page AWP ever recorded in this Chrome profile.
+            // WACZ contains only this snapshot's requests. The popup UI also
+            // sends startUpdates on this port, so another collections message
+            // may already be queued here. Correlate newColl by its unique title
+            // and by an id absent from the pre-request collection set; collId
+            // alone is global/default state and does not identify this reply.
             port.postMessage({ type: "newColl", title: collectionTitle });
             handshakeStage = "new collection";
             const created = await waitFor(
-              (m) => m && m.type === "collections" && m.collId,
+              (message) =>
+                Boolean(
+                  resolveCreatedCollectionId(
+                    message,
+                    collectionTitle,
+                    existingCollectionIds
+                  )
+                ),
               "new collection"
             );
-            const collId = created.collId;
+            const collId = resolveCreatedCollectionId(
+              created,
+              collectionTitle,
+              existingCollectionIds
+            );
             if (!collId) {
               throw new Error("AWP did not return a collection id");
             }
@@ -279,7 +322,9 @@ async function main() {
         collectionTitle: `${getEnv(
           "ARCHIVEWEBPAGE_COLLECTION_TITLE",
           "abx-dl"
-        )} - ${url}`,
+        )} - ${url} [${
+          args.snapshotId || path.basename(path.dirname(outputDir))
+        }/${crypto.randomUUID()}]`,
         timeoutMs: overallTimeoutMs,
       }
     );

--- a/tests/test_archivewebpage_concurrent_collections.py
+++ b/tests/test_archivewebpage_concurrent_collections.py
@@ -2,6 +2,7 @@ import json
 import shutil
 import signal
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TypedDict
 
@@ -198,6 +199,150 @@ const chromeSessionDir = process.argv[3];
     )
 
 
+def _select_new_collection_after_queued_updates(
+    snapshot_chrome_dir: Path,
+    env: dict[str, str],
+    collection_title: str,
+) -> tuple[str, str]:
+    script = r"""
+const chromeUtils = require(process.argv[1]);
+const awpInternal = require(process.argv[2]);
+const chromeSessionDir = process.argv[3];
+const collectionTitle = process.argv[4];
+
+(async () => {
+  const puppeteer = chromeUtils.resolvePuppeteerModule();
+  const { browser, page } = await chromeUtils.connectToPage({
+    chromeSessionDir,
+    timeoutMs: 10000,
+    requireTargetId: true,
+    puppeteer,
+  });
+  try {
+    const { id: extensionId } = awpInternal.resolveAwpExtension(chromeSessionDir);
+    if (!extensionId) throw new Error("ArchiveWeb.page extension is not loaded");
+    const tabId = await awpInternal.getChromeTabIdForPage(
+      browser,
+      page,
+      extensionId,
+      10000
+    );
+    const helperPage = await awpInternal.openAwpHelperTab(browser, extensionId, 10000);
+    try {
+      const messages = await helperPage.evaluate(
+        async ({ targetTabId, collectionTitle }) => {
+          const port = document.querySelector("wr-popup-viewer")?.port;
+          if (!port) throw new Error("AWP popup port is not ready");
+          const queue = [];
+          const waiters = [];
+          let collectionsSeen = 0;
+          let markSecondCollectionsQueued;
+          const secondCollectionsQueued = new Promise((resolve) => {
+            markSecondCollectionsQueued = resolve;
+          });
+          port.onMessage.addListener((message) => {
+            if (message?.type === "collections") {
+              collectionsSeen += 1;
+              if (collectionsSeen === 2) markSecondCollectionsQueued();
+            }
+            const waiterIndex = waiters.findIndex(({ predicate }) =>
+              predicate(message)
+            );
+            if (waiterIndex === -1) {
+              queue.push(message);
+              return;
+            }
+            const [waiter] = waiters.splice(waiterIndex, 1);
+            clearTimeout(waiter.timeout);
+            waiter.resolve(message);
+          });
+          function waitFor(predicate) {
+            return new Promise((resolve, reject) => {
+              const queuedIndex = queue.findIndex(predicate);
+              if (queuedIndex !== -1) {
+                resolve(queue.splice(queuedIndex, 1)[0]);
+                return;
+              }
+              const waiter = { predicate, resolve, timeout: null };
+              waiter.timeout = setTimeout(
+                () => reject(new Error("Timed out waiting for AWP message")),
+                10000
+              );
+              waiters.push(waiter);
+            });
+          }
+
+          // These are two genuine AWP responses on the same popup port, not
+          // synthesized messages. Consuming only the first leaves exactly the
+          // stale collections reply that the loaded popup UI can leave ahead
+          // of the hook's newColl response during a busy crawl.
+          port.postMessage({ type: "startUpdates", tabId: targetTabId });
+          port.postMessage({ type: "startUpdates", tabId: targetTabId });
+          await waitFor((message) => message?.type === "collections");
+          await secondCollectionsQueued;
+
+          port.postMessage({ type: "newColl", title: collectionTitle });
+          const created = await waitFor(
+            (message) =>
+              message?.type === "collections" &&
+              message.collections?.some(
+                (item) => item.title === collectionTitle
+              )
+          );
+          return [
+            ...queue.filter((message) => message?.type === "collections"),
+            created,
+          ];
+        },
+        { targetTabId: tabId, collectionTitle }
+      );
+      const selected = messages.find((message) =>
+        Boolean(
+          awpInternal.resolveCreatedCollectionId(message, collectionTitle)
+        )
+      );
+      const selectedId = awpInternal.resolveCreatedCollectionId(
+        selected,
+        collectionTitle
+      );
+      const created = messages.find((message) =>
+        message.collections?.some((item) => item.title === collectionTitle)
+      );
+      const matchingId = created.collections.find(
+        (item) => item.title === collectionTitle
+      ).id;
+      process.stdout.write(JSON.stringify({ selectedId, matchingId }));
+    } finally {
+      await helperPage.close({ runBeforeUnload: false }).catch(() => {});
+    }
+  } finally {
+    await browser.disconnect();
+  }
+})().catch((error) => {
+  console.error(error && (error.stack || error.message || String(error)));
+  process.exit(1);
+});
+"""
+    result = subprocess.run(
+        [
+            env["NODE_BINARY"],
+            "-e",
+            script,
+            str(CHROME_UTILS),
+            str(AWP_INTERNAL),
+            str(snapshot_chrome_dir),
+            collection_title,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    selected = json.loads(result.stdout)
+    return selected["selectedId"], selected["matchingId"]
+
+
 def _publish_child_snapshot_session(
     crawl_chrome_dir: Path,
     child_chrome_dir: Path,
@@ -271,34 +416,72 @@ def test_start_reassigns_inherited_tab_recorder_to_its_requested_collection(
         first_status = _read_awp_status(first_chrome_dir, first_env)
         assert first_status["collId"] == first_state["collId"]
 
-        child_target_id = _open_child_target(first_chrome_dir, first_env)
-        second_snapshot_dir = tmp_path / "snapshots" / "second"
-        second_chrome_dir = second_snapshot_dir / "chrome"
-        second_env = env | {"SNAP_DIR": str(second_snapshot_dir)}
-        _publish_child_snapshot_session(
-            crawl_chrome_dir,
-            second_chrome_dir,
-            child_target_id,
-            second_env,
+        selected_id, matching_id = _select_new_collection_after_queued_updates(
+            first_chrome_dir,
+            first_env,
+            "queued-collections-regression",
+        )
+        assert selected_id == matching_id, (
+            "The newColl response selector consumed an older queued collections "
+            "message instead of the collection with the requested title"
         )
 
-        inherited_status = _read_awp_status(second_chrome_dir, second_env)
-        assert inherited_status["collId"] == first_state["collId"]
+        # Exercise the user-facing inherited-tab path with the same four-way
+        # snapshot concurrency as ArchiveBox. The lower-stack assertion above
+        # covers queued newColl correlation; these hooks prove each real child
+        # recorder still moves off its opener's collection independently.
+        child_runs: list[tuple[Path, Path, dict[str, str], str]] = []
+        for index in range(4):
+            child_target_id = _open_child_target(first_chrome_dir, first_env)
+            child_snapshot_dir = tmp_path / "snapshots" / f"child-{index}"
+            child_chrome_dir = child_snapshot_dir / "chrome"
+            child_env = env | {"SNAP_DIR": str(child_snapshot_dir)}
+            child_url = f"{chrome_test_url}#child-{index}"
+            _publish_child_snapshot_session(
+                crawl_chrome_dir,
+                child_chrome_dir,
+                child_target_id,
+                child_env,
+            )
+            if index == 0:
+                inherited_status = _read_awp_status(child_chrome_dir, child_env)
+                assert inherited_status["collId"] == first_state["collId"]
+            child_runs.append(
+                (child_snapshot_dir, child_chrome_dir, child_env, child_url),
+            )
 
-        second_start = _run_start_hook(second_snapshot_dir, second_env, chrome_test_url)
-        assert second_start.returncode == 0, (
-            f"Second AWP start failed:\nstdout={second_start.stdout}\nstderr={second_start.stderr}"
-        )
-        second_state = json.loads(
-            (second_snapshot_dir / "archivewebpage" / "recording.json").read_text(),
-        )
-        assert second_state["collId"] != first_state["collId"]
+        with ThreadPoolExecutor(max_workers=len(child_runs)) as executor:
+            child_starts = list(
+                executor.map(
+                    lambda run: _run_start_hook(run[0], run[2], run[3]),
+                    child_runs,
+                ),
+            )
+        for child_start in child_starts:
+            assert child_start.returncode == 0, (
+                "Concurrent child AWP start failed:\n"
+                f"stdout={child_start.stdout}\nstderr={child_start.stderr}"
+            )
 
-        second_status = _read_awp_status(second_chrome_dir, second_env)
-        assert second_status["collId"] == second_state["collId"], (
-            "The ArchiveWeb.page start hook reported success without moving the "
-            "child tab from its inherited collection to the newly requested collection"
+        child_states = [
+            json.loads(
+                (snapshot_dir / "archivewebpage" / "recording.json").read_text(),
+            )
+            for snapshot_dir, _chrome_dir, _child_env, _url in child_runs
+        ]
+        child_collection_ids = {state["collId"] for state in child_states}
+        assert first_state["collId"] not in child_collection_ids
+        assert len(child_collection_ids) == len(child_runs), (
+            "Concurrent ArchiveWeb.page newColl requests reused a collection id"
         )
+
+        for child_run, child_state in zip(child_runs, child_states, strict=True):
+            _snapshot_dir, child_chrome_dir, child_env, _url = child_run
+            child_status = _read_awp_status(child_chrome_dir, child_env)
+            assert child_status["collId"] == child_state["collId"], (
+                "The ArchiveWeb.page start hook reported success without moving the "
+                "child tab from its inherited collection to the newly requested collection"
+            )
         first_status_after_reassignment = _read_awp_status(first_chrome_dir, first_env)
         assert first_status_after_reassignment["recording"] is True
         assert first_status_after_reassignment["collId"] == first_state["collId"]

--- a/tests/test_archivewebpage_concurrent_collections.py
+++ b/tests/test_archivewebpage_concurrent_collections.py
@@ -3,12 +3,14 @@ import shutil
 import signal
 import subprocess
 from pathlib import Path
+from typing import TypedDict
 
 import pytest
 
 from abx_plugins.plugins.base.testing import install_required_binary_from_config
 from abx_plugins.plugins.chrome.tests.chrome_test_helpers import (
     CHROME_UTILS,
+    kill_chromium_session,
     launch_chromium_session,
     launch_snapshot_tab,
     setup_test_env,
@@ -23,6 +25,12 @@ ARCHIVEWEBPAGE_START_HOOK = (
     ARCHIVEWEBPAGE_PLUGIN_DIR / "on_Snapshot__16_archivewebpage_start.js"
 )
 AWP_INTERNAL = ARCHIVEWEBPAGE_PLUGIN_DIR / "awp_internal.js"
+
+
+class AwpStatus(TypedDict):
+    type: str
+    recording: bool
+    collId: str
 
 
 def _run_start_hook(
@@ -109,7 +117,7 @@ const chromeSessionDir = process.argv[2];
     return result.stdout.strip()
 
 
-def _read_awp_status(snapshot_chrome_dir: Path, env: dict[str, str]) -> dict:
+def _read_awp_status(snapshot_chrome_dir: Path, env: dict[str, str]) -> AwpStatus:
     script = r"""
 const chromeUtils = require(process.argv[1]);
 const awpInternal = require(process.argv[2]);
@@ -179,7 +187,15 @@ const chromeSessionDir = process.argv[3];
         env=env,
     )
     assert result.returncode == 0, result.stderr
-    return json.loads(result.stdout)
+    status = json.loads(result.stdout)
+    assert status["type"] == "status"
+    assert isinstance(status["recording"], bool)
+    assert isinstance(status["collId"], str)
+    return AwpStatus(
+        type=status["type"],
+        recording=status["recording"],
+        collId=status["collId"],
+    )
 
 
 def _publish_child_snapshot_session(
@@ -288,16 +304,16 @@ def test_start_reassigns_inherited_tab_recorder_to_its_requested_collection(
         assert first_status_after_reassignment["collId"] == first_state["collId"]
     finally:
         if first_tab_process is not None:
-            first_tab_process.send_signal(signal.SIGTERM)
-            first_tab_process.wait(timeout=20)
+            if first_tab_process.poll() is None:
+                first_tab_process.send_signal(signal.SIGTERM)
+            try:
+                first_tab_process.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                first_tab_process.kill()
+                first_tab_process.wait(timeout=5)
             for attr in ("_stdout_handle", "_stderr_handle"):
                 handle = getattr(first_tab_process, attr, None)
                 if handle:
                     handle.close()
         if launch_process is not None:
-            launch_process.send_signal(signal.SIGTERM)
-            launch_process.wait(timeout=20)
-            for attr in ("_stdout_handle", "_stderr_handle"):
-                handle = getattr(launch_process, attr, None)
-                if handle:
-                    handle.close()
+            kill_chromium_session(launch_process, crawl_chrome_dir)

--- a/tests/test_archivewebpage_concurrent_collections.py
+++ b/tests/test_archivewebpage_concurrent_collections.py
@@ -32,6 +32,12 @@ class AwpStatus(TypedDict):
     type: str
     recording: bool
     collId: str
+    collectionTitle: str
+
+
+class CollectionSelection(TypedDict):
+    selectedId: str
+    matchingId: str
 
 
 def _run_start_hook(
@@ -45,7 +51,11 @@ def _run_start_hook(
         [
             str(ARCHIVEWEBPAGE_START_HOOK),
             f"--url={url}",
-            f"--snapshot-id={snapshot_dir.name}",
+            # Keep the model identity deliberately different from the output
+            # directory name. parseArgs normalizes --snapshot-id to
+            # args.snapshot_id; if the hook accidentally reads snapshotId, its
+            # directory fallback masks the bug unless these values differ.
+            f"--snapshot-id=model-{snapshot_dir.name}",
             "--crawl-id=test-archivewebpage-concurrent-collections",
         ],
         cwd=output_dir,
@@ -147,15 +157,25 @@ const chromeSessionDir = process.argv[3];
         const port = document.querySelector("wr-popup-viewer")?.port;
         if (!port) throw new Error("AWP popup port is not ready");
         return await new Promise((resolve, reject) => {
+          let recordingStatus = null;
+          let collections = [];
           const timeout = setTimeout(() => {
             port.onMessage.removeListener(onMessage);
             reject(new Error("Timed out waiting for AWP recording status"));
           }, 10000);
           const onMessage = (message) => {
-            if (message?.type !== "status" || message.recording !== true) return;
+            if (message?.type === "collections" && Array.isArray(message.collections)) {
+              collections = message.collections;
+            } else if (message?.type === "status" && message.recording === true) {
+              recordingStatus = message;
+            }
+            const collection = recordingStatus
+              ? collections.find((item) => item.id === recordingStatus.collId)
+              : null;
+            if (!recordingStatus || !collection) return;
             clearTimeout(timeout);
             port.onMessage.removeListener(onMessage);
-            resolve(message);
+            resolve({ ...recordingStatus, collectionTitle: collection.title });
           };
           port.onMessage.addListener(onMessage);
           port.postMessage({ type: "startUpdates", tabId: targetTabId });
@@ -192,10 +212,12 @@ const chromeSessionDir = process.argv[3];
     assert status["type"] == "status"
     assert isinstance(status["recording"], bool)
     assert isinstance(status["collId"], str)
+    assert isinstance(status["collectionTitle"], str)
     return AwpStatus(
         type=status["type"],
         recording=status["recording"],
         collId=status["collId"],
+        collectionTitle=status["collectionTitle"],
     )
 
 
@@ -340,7 +362,14 @@ const collectionTitle = process.argv[4];
     )
     assert result.returncode == 0, result.stderr
     selected = json.loads(result.stdout)
-    return selected["selectedId"], selected["matchingId"]
+    assert isinstance(selected, dict)
+    assert isinstance(selected.get("selectedId"), str)
+    assert isinstance(selected.get("matchingId"), str)
+    typed_selection = CollectionSelection(
+        selectedId=selected["selectedId"],
+        matchingId=selected["matchingId"],
+    )
+    return typed_selection["selectedId"], typed_selection["matchingId"]
 
 
 def _publish_child_snapshot_session(
@@ -415,6 +444,12 @@ def test_start_reassigns_inherited_tab_recorder_to_its_requested_collection(
         )
         first_status = _read_awp_status(first_chrome_dir, first_env)
         assert first_status["collId"] == first_state["collId"]
+        assert (
+            f"[model-{first_snapshot_dir.name}/" in first_status["collectionTitle"]
+        ), (
+            "The collection title lost the --snapshot-id model identity and silently "
+            "fell back to the output directory name"
+        )
 
         selected_id, matching_id = _select_new_collection_after_queued_updates(
             first_chrome_dir,

--- a/tests/test_archivewebpage_concurrent_collections.py
+++ b/tests/test_archivewebpage_concurrent_collections.py
@@ -1,0 +1,303 @@
+import json
+import shutil
+import signal
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from abx_plugins.plugins.base.testing import install_required_binary_from_config
+from abx_plugins.plugins.chrome.tests.chrome_test_helpers import (
+    CHROME_UTILS,
+    launch_chromium_session,
+    launch_snapshot_tab,
+    setup_test_env,
+    wait_for_chrome_session_state,
+)
+
+
+pytestmark = pytest.mark.usefixtures("ensure_chrome_test_prereqs")
+
+ARCHIVEWEBPAGE_PLUGIN_DIR = CHROME_UTILS.parent.parent / "archivewebpage"
+ARCHIVEWEBPAGE_START_HOOK = (
+    ARCHIVEWEBPAGE_PLUGIN_DIR / "on_Snapshot__16_archivewebpage_start.js"
+)
+AWP_INTERNAL = ARCHIVEWEBPAGE_PLUGIN_DIR / "awp_internal.js"
+
+
+def _run_start_hook(
+    snapshot_dir: Path,
+    env: dict[str, str],
+    url: str,
+) -> subprocess.CompletedProcess[str]:
+    output_dir = snapshot_dir / "archivewebpage"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return subprocess.run(
+        [
+            str(ARCHIVEWEBPAGE_START_HOOK),
+            f"--url={url}",
+            f"--snapshot-id={snapshot_dir.name}",
+            "--crawl-id=test-archivewebpage-concurrent-collections",
+        ],
+        cwd=output_dir,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+
+
+def _open_child_target(snapshot_chrome_dir: Path, env: dict[str, str]) -> str:
+    script = r"""
+const chromeUtils = require(process.argv[1]);
+const chromeSessionDir = process.argv[2];
+
+(async () => {
+  const puppeteer = chromeUtils.resolvePuppeteerModule();
+  const { browser, page } = await chromeUtils.connectToPage({
+    chromeSessionDir,
+    timeoutMs: 10000,
+    requireTargetId: true,
+    puppeteer,
+  });
+  try {
+    const existingTargetIds = new Set(
+      browser.targets().map((target) => chromeUtils.getTargetIdFromTarget(target))
+    );
+    const childTargetPromise = browser.waitForTarget(
+      (target) =>
+        target.type() === "page" &&
+        !existingTargetIds.has(chromeUtils.getTargetIdFromTarget(target)),
+      { timeout: 10000 }
+    );
+    const pageSession = await page.target().createCDPSession();
+    try {
+      await pageSession.send("Runtime.evaluate", {
+        expression: "window.open('about:blank', '_blank')",
+        userGesture: true,
+      });
+    } finally {
+      await pageSession.detach();
+    }
+    const childTarget = await childTargetPromise;
+    const targetId = chromeUtils.getTargetIdFromTarget(childTarget);
+    if (!targetId) throw new Error("Child tab has no CDP target id");
+    process.stdout.write(targetId);
+  } finally {
+    await browser.disconnect();
+  }
+})().catch((error) => {
+  console.error(error && (error.stack || error.message || String(error)));
+  process.exit(1);
+});
+"""
+    result = subprocess.run(
+        [
+            env["NODE_BINARY"],
+            "-e",
+            script,
+            str(CHROME_UTILS),
+            str(snapshot_chrome_dir),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip(), result
+    return result.stdout.strip()
+
+
+def _read_awp_status(snapshot_chrome_dir: Path, env: dict[str, str]) -> dict:
+    script = r"""
+const chromeUtils = require(process.argv[1]);
+const awpInternal = require(process.argv[2]);
+const chromeSessionDir = process.argv[3];
+
+(async () => {
+  const puppeteer = chromeUtils.resolvePuppeteerModule();
+  const { browser, page } = await chromeUtils.connectToPage({
+    chromeSessionDir,
+    timeoutMs: 10000,
+    requireTargetId: true,
+    puppeteer,
+  });
+  try {
+    const { id: extensionId } = awpInternal.resolveAwpExtension(chromeSessionDir);
+    if (!extensionId) throw new Error("ArchiveWeb.page extension is not loaded");
+    const tabId = await awpInternal.getChromeTabIdForPage(
+      browser,
+      page,
+      extensionId,
+      10000
+    );
+    const helperPage = await awpInternal.openAwpHelperTab(browser, extensionId, 10000);
+    try {
+      const status = await helperPage.evaluate(async (targetTabId) => {
+        const port = document.querySelector("wr-popup-viewer")?.port;
+        if (!port) throw new Error("AWP popup port is not ready");
+        return await new Promise((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            port.onMessage.removeListener(onMessage);
+            reject(new Error("Timed out waiting for AWP recording status"));
+          }, 10000);
+          const onMessage = (message) => {
+            if (message?.type !== "status" || message.recording !== true) return;
+            clearTimeout(timeout);
+            port.onMessage.removeListener(onMessage);
+            resolve(message);
+          };
+          port.onMessage.addListener(onMessage);
+          port.postMessage({ type: "startUpdates", tabId: targetTabId });
+        });
+      }, tabId);
+      process.stdout.write(JSON.stringify(status));
+    } finally {
+      await helperPage.close({ runBeforeUnload: false }).catch(() => {});
+    }
+  } finally {
+    await browser.disconnect();
+  }
+})().catch((error) => {
+  console.error(error && (error.stack || error.message || String(error)));
+  process.exit(1);
+});
+"""
+    result = subprocess.run(
+        [
+            env["NODE_BINARY"],
+            "-e",
+            script,
+            str(CHROME_UTILS),
+            str(AWP_INTERNAL),
+            str(snapshot_chrome_dir),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _publish_child_snapshot_session(
+    crawl_chrome_dir: Path,
+    child_chrome_dir: Path,
+    child_target_id: str,
+    env: dict[str, str],
+) -> None:
+    child_chrome_dir.mkdir(parents=True)
+    for file_name in ("browser.json", "cdp_url.txt", "chrome.pid"):
+        shutil.copy2(crawl_chrome_dir / file_name, child_chrome_dir / file_name)
+    (child_chrome_dir / "target_id.txt").write_text(f"{child_target_id}\n")
+    (child_chrome_dir / "url.txt").write_text("about:blank\n")
+    wait_for_chrome_session_state(
+        child_chrome_dir,
+        env=env,
+        require_target_id=True,
+        require_browser_ready=True,
+        require_connectable=True,
+    )
+
+
+def test_start_reassigns_inherited_tab_recorder_to_its_requested_collection(
+    tmp_path,
+    chrome_test_url,
+):
+    env = setup_test_env(tmp_path)
+    env.update(
+        {
+            "CHROME_HEADLESS": "true",
+            "CHROME_ISOLATION": "crawl",
+            "CHROME_KEEPALIVE": "false",
+        },
+    )
+    extensions_dir = Path(env["CHROMEWEBSTORE_EXTENSIONS_DIR"])
+    installed = install_required_binary_from_config(
+        ARCHIVEWEBPAGE_PLUGIN_DIR,
+        "archivewebpage",
+        env=env,
+    )
+    assert installed.loaded_abspath is not None
+    assert extensions_dir.joinpath("archivewebpage.extension.json").is_file()
+
+    crawl_dir = Path(env["CRAWL_DIR"])
+    crawl_chrome_dir = crawl_dir / "chrome"
+    launch_process = None
+    first_tab_process = None
+    try:
+        launch_process, _cdp_url = launch_chromium_session(
+            env,
+            crawl_chrome_dir,
+            "test-archivewebpage-concurrent-collections",
+        )
+
+        first_snapshot_dir = tmp_path / "snapshots" / "first"
+        first_chrome_dir = first_snapshot_dir / "chrome"
+        first_chrome_dir.mkdir(parents=True)
+        first_env = env | {"SNAP_DIR": str(first_snapshot_dir)}
+        first_tab_process = launch_snapshot_tab(
+            snapshot_chrome_dir=first_chrome_dir,
+            tab_env=first_env,
+            test_url=chrome_test_url,
+            snapshot_id="first",
+            crawl_id="test-archivewebpage-concurrent-collections",
+        )
+        first_start = _run_start_hook(first_snapshot_dir, first_env, chrome_test_url)
+        assert first_start.returncode == 0, (
+            f"First AWP start failed:\nstdout={first_start.stdout}\nstderr={first_start.stderr}"
+        )
+        first_state = json.loads(
+            (first_snapshot_dir / "archivewebpage" / "recording.json").read_text(),
+        )
+        first_status = _read_awp_status(first_chrome_dir, first_env)
+        assert first_status["collId"] == first_state["collId"]
+
+        child_target_id = _open_child_target(first_chrome_dir, first_env)
+        second_snapshot_dir = tmp_path / "snapshots" / "second"
+        second_chrome_dir = second_snapshot_dir / "chrome"
+        second_env = env | {"SNAP_DIR": str(second_snapshot_dir)}
+        _publish_child_snapshot_session(
+            crawl_chrome_dir,
+            second_chrome_dir,
+            child_target_id,
+            second_env,
+        )
+
+        inherited_status = _read_awp_status(second_chrome_dir, second_env)
+        assert inherited_status["collId"] == first_state["collId"]
+
+        second_start = _run_start_hook(second_snapshot_dir, second_env, chrome_test_url)
+        assert second_start.returncode == 0, (
+            f"Second AWP start failed:\nstdout={second_start.stdout}\nstderr={second_start.stderr}"
+        )
+        second_state = json.loads(
+            (second_snapshot_dir / "archivewebpage" / "recording.json").read_text(),
+        )
+        assert second_state["collId"] != first_state["collId"]
+
+        second_status = _read_awp_status(second_chrome_dir, second_env)
+        assert second_status["collId"] == second_state["collId"], (
+            "The ArchiveWeb.page start hook reported success without moving the "
+            "child tab from its inherited collection to the newly requested collection"
+        )
+        first_status_after_reassignment = _read_awp_status(first_chrome_dir, first_env)
+        assert first_status_after_reassignment["recording"] is True
+        assert first_status_after_reassignment["collId"] == first_state["collId"]
+    finally:
+        if first_tab_process is not None:
+            first_tab_process.send_signal(signal.SIGTERM)
+            first_tab_process.wait(timeout=20)
+            for attr in ("_stdout_handle", "_stderr_handle"):
+                handle = getattr(first_tab_process, attr, None)
+                if handle:
+                    handle.close()
+        if launch_process is not None:
+            launch_process.send_signal(signal.SIGTERM)
+            launch_process.wait(timeout=20)
+            for attr in ("_stdout_handle", "_stderr_handle"):
+                handle = getattr(launch_process, attr, None)
+                if handle:
+                    handle.close()


### PR DESCRIPTION
## Summary

- reproduce the shared-browser failure with the real ArchiveWeb.page extension: a child tab inherits its opener collection, then the second snapshot start hook falsely reports success for a different collection
- consume popup-port messages exactly once so a new-collection wait cannot reuse stale collection/status responses
- detach only the inherited recorder on the target tab, restart that tab against its requested collection, and require the live status collection ID to match before persisting recording state
- verify the original tab remains actively recording its own collection after the child tab is reassigned

ArchiveBox context: https://github.com/ArchiveBox/ArchiveBox/issues/1847

## Red/green evidence

Before the fix, the new real-browser test failed with two different IDs:

    AssertionError: The ArchiveWeb.page start hook reported success without moving the child tab from its inherited collection to the newly requested collection
    assert actual_inherited_collection == requested_new_collection

After the fix:

    1 passed in 32.27s

Adjacent verification:

    3 passed in 87.99s

This includes the new concurrent-collection regression, the existing concurrent snapshot/extension test, and ArchiveWebPage replay-preview coverage. All prek checks on the changed files pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ArchiveWebPage start hook so child tabs inheriting a collection from their opener are reassigned to the requested collection instead of falsely reporting success.

- Correlates the newColl reply with one shared typed selector, exposed as a page binding so the hook and the real-browser test run the same logic; it matches a unique title and an id absent from the pre-request collection set, and snapshot titles now carry a random suffix so each reply is identifiable.
- Consumes popup-port messages exactly once so a new-collection wait cannot reuse stale collection/status responses.
- Detaches only the inherited recorder on the target tab, restarts it with the new collection, and confirms the live collection ID matches before persisting recording state.
- Adds a regression test that reproduces the failure with the real extension and verifies the original tab keeps recording its own collection.

<sup>Written for commit f62764f3204ee436e57a30c68ecd6cab04e7d1a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

