### PR TITLE
Keep ArchiveWebPage targets alive through export

### DIFF
--- a/abx_plugins/plugins/archivewebpage/awp_internal.js
+++ b/abx_plugins/plugins/archivewebpage/awp_internal.js
@@ -147,6 +147,71 @@ function resolveChromeDirs(cwd, crawlDirEnv) {
 
 const fs = require("fs");
 
+function observePublishedFile(filePath, timeoutMs) {
+  const directory = path.dirname(filePath);
+  const expectedName = path.basename(filePath);
+  const abortController = new AbortController();
+  let settled = false;
+  let timer = null;
+
+  const close = () => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+    if (!abortController.signal.aborted) abortController.abort();
+  };
+  const promise = new Promise((resolve, reject) => {
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      close();
+      callback(value);
+    };
+
+    timer = setTimeout(
+      () =>
+        finish(
+          reject,
+          new Error(
+            `Download ${expectedName} was not published within ${timeoutMs}ms`
+          )
+        ),
+      timeoutMs
+    );
+
+    (async () => {
+      try {
+        const watcher = fs.promises.watch(directory, {
+          signal: abortController.signal,
+        });
+        for await (const _event of watcher) {
+          try {
+            // fs.watch filenames are optional. Every notification is only a
+            // prompt to check the one exact path owned by this download.
+            const stat = await fs.promises.stat(filePath);
+            if (stat.size > 0) {
+              finish(resolve, stat);
+              return;
+            }
+          } catch (error) {
+            // Chrome can announce the temporary-file rename before its final
+            // name is visible. A later event is the publication boundary.
+            if (error?.code !== "ENOENT") {
+              finish(reject, error);
+              return;
+            }
+          }
+        }
+      } catch (error) {
+        // Abort is our normal close path. Construction and later watcher
+        // backend failures reject the same promise awaited by the stop hook.
+        if (!abortController.signal.aborted) finish(reject, error);
+      }
+    })();
+  });
+
+  return { promise, close };
+}
+
 function hasSnapshotChromeSession(dir) {
   if (!dir) return false;
   // The snapshot-level chrome session is identified by target_id.txt being
@@ -200,4 +265,5 @@ module.exports = {
   resolveChromeDirs,
   pickChromeSessionDir,
   resolveCreatedCollectionId,
+  observePublishedFile,
 };

--- a/abx_plugins/plugins/archivewebpage/awp_internal.js
+++ b/abx_plugins/plugins/archivewebpage/awp_internal.js
@@ -84,18 +84,12 @@ async function getChromeTabIdForPage(browser, page, extensionId, timeoutMs) {
  */
 async function openAwpHelperTab(browser, extensionId, timeoutMs = 5000) {
   const helperUrl = `chrome-extension://${extensionId}/popup.html`;
-  const browserSession = await browser.target().createCDPSession();
-  let targetId = null;
-  try {
-    const result = await browserSession.send("Target.createTarget", {
-      url: helperUrl,
-    });
-    targetId = result.targetId;
-  } finally {
-    try {
-      await browserSession.detach();
-    } catch (error) {}
-  }
+  const result = await chromeUtils.sendBrowserCommand(
+    browser,
+    "Target.createTarget",
+    { url: helperUrl }
+  );
+  const targetId = result.targetId;
   if (!targetId) {
     throw new Error("Target.createTarget did not return a targetId");
   }

--- a/abx_plugins/plugins/archivewebpage/on_Snapshot__65_archivewebpage_stop.js
+++ b/abx_plugins/plugins/archivewebpage/on_Snapshot__65_archivewebpage_stop.js
@@ -53,15 +53,14 @@ async function moveAcrossMounts(src, dest) {
 function observePublishedFile(filePath, timeoutMs) {
   const directory = path.dirname(filePath);
   const expectedName = path.basename(filePath);
+  const abortController = new AbortController();
   let settled = false;
-  let watcher = null;
   let timer = null;
 
   const close = () => {
     if (timer) clearTimeout(timer);
     timer = null;
-    if (watcher) watcher.close();
-    watcher = null;
+    if (!abortController.signal.aborted) abortController.abort();
   };
   const promise = new Promise((resolve, reject) => {
     const finish = (callback, value) => {
@@ -70,18 +69,7 @@ function observePublishedFile(filePath, timeoutMs) {
       close();
       callback(value);
     };
-    watcher = fs.watch(directory, async (_eventType, filename) => {
-      if (filename && filename.toString() !== expectedName) return;
-      try {
-        const stat = await fs.promises.stat(filePath);
-        if (stat.size > 0) finish(resolve, stat);
-      } catch (error) {
-        // Chrome can announce the temporary-file rename before its final name
-        // is visible. A later filesystem event is the publication boundary.
-        if (error?.code !== "ENOENT") finish(reject, error);
-      }
-    });
-    watcher.on("error", (error) => finish(reject, error));
+
     timer = setTimeout(
       () =>
         finish(
@@ -92,6 +80,36 @@ function observePublishedFile(filePath, timeoutMs) {
         ),
       timeoutMs
     );
+
+    (async () => {
+      try {
+        const watcher = fs.promises.watch(directory, {
+          signal: abortController.signal,
+        });
+        for await (const _event of watcher) {
+          try {
+            // fs.watch filenames are optional. Every notification is only a
+            // prompt to check the one exact path owned by this download.
+            const stat = await fs.promises.stat(filePath);
+            if (stat.size > 0) {
+              finish(resolve, stat);
+              return;
+            }
+          } catch (error) {
+            // Chrome can announce the temporary-file rename before its final
+            // name is visible. A later event is the publication boundary.
+            if (error?.code !== "ENOENT") {
+              finish(reject, error);
+              return;
+            }
+          }
+        }
+      } catch (error) {
+        // Abort is our normal close path. Construction and later watcher
+        // backend failures reject the same promise awaited by the stop hook.
+        if (!abortController.signal.aborted) finish(reject, error);
+      }
+    })();
   });
 
   return { promise, close };
@@ -342,7 +360,11 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(`Fatal error: ${error.message || error}`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`Fatal error: ${error.message || error}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { observePublishedFile };

--- a/abx_plugins/plugins/archivewebpage/on_Snapshot__65_archivewebpage_stop.js
+++ b/abx_plugins/plugins/archivewebpage/on_Snapshot__65_archivewebpage_stop.js
@@ -27,6 +27,7 @@ const {
   openAwpHelperTab,
   resolveChromeDirs,
   pickChromeSessionDir,
+  observePublishedFile,
 } = require("./awp_internal.js");
 
 const hookConfig = loadConfig();
@@ -48,71 +49,6 @@ async function moveAcrossMounts(src, dest) {
     await fs.promises.copyFile(src, dest);
     await fs.promises.unlink(src);
   }
-}
-
-function observePublishedFile(filePath, timeoutMs) {
-  const directory = path.dirname(filePath);
-  const expectedName = path.basename(filePath);
-  const abortController = new AbortController();
-  let settled = false;
-  let timer = null;
-
-  const close = () => {
-    if (timer) clearTimeout(timer);
-    timer = null;
-    if (!abortController.signal.aborted) abortController.abort();
-  };
-  const promise = new Promise((resolve, reject) => {
-    const finish = (callback, value) => {
-      if (settled) return;
-      settled = true;
-      close();
-      callback(value);
-    };
-
-    timer = setTimeout(
-      () =>
-        finish(
-          reject,
-          new Error(
-            `Download ${expectedName} was not published within ${timeoutMs}ms`
-          )
-        ),
-      timeoutMs
-    );
-
-    (async () => {
-      try {
-        const watcher = fs.promises.watch(directory, {
-          signal: abortController.signal,
-        });
-        for await (const _event of watcher) {
-          try {
-            // fs.watch filenames are optional. Every notification is only a
-            // prompt to check the one exact path owned by this download.
-            const stat = await fs.promises.stat(filePath);
-            if (stat.size > 0) {
-              finish(resolve, stat);
-              return;
-            }
-          } catch (error) {
-            // Chrome can announce the temporary-file rename before its final
-            // name is visible. A later event is the publication boundary.
-            if (error?.code !== "ENOENT") {
-              finish(reject, error);
-              return;
-            }
-          }
-        }
-      } catch (error) {
-        // Abort is our normal close path. Construction and later watcher
-        // backend failures reject the same promise awaited by the stop hook.
-        if (!abortController.signal.aborted) finish(reject, error);
-      }
-    })();
-  });
-
-  return { promise, close };
 }
 
 function readRecordingState() {
@@ -360,11 +296,7 @@ async function main() {
   }
 }
 
-if (require.main === module) {
-  main().catch((error) => {
-    console.error(`Fatal error: ${error.message || error}`);
-    process.exit(1);
-  });
-}
-
-module.exports = { observePublishedFile };
+main().catch((error) => {
+  console.error(`Fatal error: ${error.message || error}`);
+  process.exit(1);
+});

--- a/abx_plugins/plugins/archivewebpage/on_Snapshot__65_archivewebpage_stop.js
+++ b/abx_plugins/plugins/archivewebpage/on_Snapshot__65_archivewebpage_stop.js
@@ -71,7 +71,7 @@ function observePublishedFile(filePath, timeoutMs) {
       callback(value);
     };
     watcher = fs.watch(directory, async (_eventType, filename) => {
-      if (filename?.toString() !== expectedName) return;
+      if (filename && filename.toString() !== expectedName) return;
       try {
         const stat = await fs.promises.stat(filePath);
         if (stat.size > 0) finish(resolve, stat);
@@ -81,6 +81,7 @@ function observePublishedFile(filePath, timeoutMs) {
         if (error?.code !== "ENOENT") finish(reject, error);
       }
     });
+    watcher.on("error", (error) => finish(reject, error));
     timer = setTimeout(
       () =>
         finish(

--- a/abx_plugins/plugins/archivewebpage/on_Snapshot__65_archivewebpage_stop.js
+++ b/abx_plugins/plugins/archivewebpage/on_Snapshot__65_archivewebpage_stop.js
@@ -50,6 +50,52 @@ async function moveAcrossMounts(src, dest) {
   }
 }
 
+function observePublishedFile(filePath, timeoutMs) {
+  const directory = path.dirname(filePath);
+  const expectedName = path.basename(filePath);
+  let settled = false;
+  let watcher = null;
+  let timer = null;
+
+  const close = () => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+    if (watcher) watcher.close();
+    watcher = null;
+  };
+  const promise = new Promise((resolve, reject) => {
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      close();
+      callback(value);
+    };
+    watcher = fs.watch(directory, async (_eventType, filename) => {
+      if (filename?.toString() !== expectedName) return;
+      try {
+        const stat = await fs.promises.stat(filePath);
+        if (stat.size > 0) finish(resolve, stat);
+      } catch (error) {
+        // Chrome can announce the temporary-file rename before its final name
+        // is visible. A later filesystem event is the publication boundary.
+        if (error?.code !== "ENOENT") finish(reject, error);
+      }
+    });
+    timer = setTimeout(
+      () =>
+        finish(
+          reject,
+          new Error(
+            `Download ${expectedName} was not published within ${timeoutMs}ms`
+          )
+        ),
+      timeoutMs
+    );
+  });
+
+  return { promise, close };
+}
+
 function readRecordingState() {
   const statePath = path.join(outputDir, RECORDING_STATE_FILENAME);
   const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
@@ -156,19 +202,22 @@ async function downloadExactWacz(
     requestedFilename.replace(/\.wacz$/i, "")
   )}`;
   const downloadedPath = path.join(downloadDir, requestedFilename);
-  const session = await browser.target().createCDPSession();
+  const browserConnection = chromeUtils.getBrowserConnection(browser);
+  let publishedFile = null;
   let targetId = null;
   let downloadSession = null;
 
   try {
-    await session.send("Browser.setDownloadBehavior", {
+    await chromeUtils.sendBrowserCommand(browser, "Browser.setDownloadBehavior", {
       behavior: "allow",
       downloadPath: downloadDir,
       eventsEnabled: true,
     });
-    const created = await session.send("Target.createTarget", {
-      url: "about:blank",
-    });
+    const created = await chromeUtils.sendBrowserCommand(
+      browser,
+      "Target.createTarget",
+      { url: "about:blank" }
+    );
     targetId = created.targetId;
     const matchesTarget = (target) =>
       chromeUtils.getTargetIdFromTarget(target) === targetId;
@@ -180,27 +229,30 @@ async function downloadExactWacz(
       throw new Error(`WACZ download target ${targetId} has no page`);
     }
     downloadSession = await target.createCDPSession();
+    publishedFile = observePublishedFile(downloadedPath, timeoutMs);
     const downloadCompleted = chromeUtils.waitForBrowserDownload(
-      session,
+      browserConnection,
       requestedFilename,
       timeoutMs
     );
     await downloadSession.send("Page.navigate", { url: dlUrl });
-    await downloadCompleted;
-    const stat = await fs.promises.stat(downloadedPath);
-    if (stat.size <= 0) {
-      throw new Error("WACZ download is empty");
-    }
+    // Chrome's CDP contract explicitly does not guarantee that the final path
+    // exists when Browser.downloadProgress reports "completed". Require both
+    // browser completion and the exact filesystem publication event before we
+    // take ownership of the WACZ.
+    await Promise.all([downloadCompleted, publishedFile.promise]);
     if (path.resolve(downloadedPath) !== path.resolve(destPath)) {
       await moveAcrossMounts(downloadedPath, destPath);
     }
     return (await fs.promises.stat(destPath)).size;
   } finally {
+    publishedFile?.close();
     await downloadSession?.detach().catch(() => {});
     if (targetId) {
-      await session.send("Target.closeTarget", { targetId }).catch(() => {});
+      await chromeUtils
+        .sendBrowserCommand(browser, "Target.closeTarget", { targetId })
+        .catch(() => {});
     }
-    await session.detach().catch(() => {});
   }
 }
 

--- a/abx_plugins/plugins/chrome/chrome_utils.js
+++ b/abx_plugins/plugins/chrome/chrome_utils.js
@@ -2866,9 +2866,6 @@ async function setBrowserDownloadBehavior(options = {}) {
   }
 
   try {
-    if (!browser) {
-      throw new Error("browser connection is unavailable");
-    }
     await sendBrowserCommand(browser, "Browser.setDownloadBehavior", {
       behavior: "allow",
       downloadPath,

--- a/abx_plugins/plugins/chrome/chrome_utils.js
+++ b/abx_plugins/plugins/chrome/chrome_utils.js
@@ -1917,6 +1917,29 @@ async function loadExtensionFromTarget(extensions, target, options = {}) {
   return new_extension;
 }
 
+/**
+ * Return Puppeteer's root browser CDP connection.
+ *
+ * Browser-domain commands already belong on this connection. Attaching a
+ * child session through browser.target() first creates an unnecessary
+ * Target.attachToTarget race against Puppeteer's transient synthetic browser
+ * target when several snapshot processes share one Chrome instance.
+ */
+function getBrowserConnection(browser) {
+  const connection =
+    typeof browser?.connection === "function"
+      ? browser.connection()
+      : browser?._connection || null;
+  if (!connection || typeof connection.send !== "function") {
+    throw new Error("Puppeteer browser root CDP connection is unavailable");
+  }
+  return connection;
+}
+
+async function sendBrowserCommand(browser, method, params = {}) {
+  return await getBrowserConnection(browser).send(method, params);
+}
+
 async function loadUnpackedExtensionsIntoBrowser(
   browser,
   extensions,
@@ -1930,22 +1953,6 @@ async function loadUnpackedExtensionsIntoBrowser(
   console.error(
     `[⚙️] Loading ${validExtensions.length} unpacked chrome extensions into browser...`
   );
-  const browserConnection =
-    typeof browser.connection === "function"
-      ? browser.connection()
-      : browser._connection || null;
-  let cdpSession = null;
-
-  async function sendBrowserCommand(method, params) {
-    if (browserConnection && typeof browserConnection.send === "function") {
-      return await browserConnection.send(method, params);
-    }
-    if (!cdpSession) {
-      cdpSession = await browser.target().createCDPSession();
-    }
-    return await cdpSession.send(method, params);
-  }
-
   const runtimeUser =
     typeof process.getuid === "function" ? process.getuid() : "user";
   const lockRoot = path.join(os.tmpdir(), `abx-chrome-${runtimeUser}`);
@@ -1991,9 +1998,11 @@ async function loadUnpackedExtensionsIntoBrowser(
         recursive: true,
         force: true,
       });
-      const { id } = await sendBrowserCommand("Extensions.loadUnpacked", {
-        path: extension.unpacked_path,
-      });
+      const { id } = await sendBrowserCommand(
+        browser,
+        "Extensions.loadUnpacked",
+        { path: extension.unpacked_path }
+      );
       if (!id) {
         throw new Error(
           `Extensions.loadUnpacked did not return an id for ${extension.unpacked_path}`
@@ -2021,22 +2030,14 @@ async function loadUnpackedExtensionsIntoBrowser(
     // Hooks resolve their own short-lived MV3 worker target when they use it.
   }
 
-  try {
-    const extensionLoadResults = await Promise.allSettled(
-      validExtensions.map(loadExtension)
-    );
-    const failedExtensionLoad = extensionLoadResults.find(
-      (result) => result.status === "rejected"
-    );
-    if (failedExtensionLoad) {
-      throw failedExtensionLoad.reason;
-    }
-  } finally {
-    if (cdpSession) {
-      try {
-        await cdpSession.detach();
-      } catch (error) {}
-    }
+  const extensionLoadResults = await Promise.allSettled(
+    validExtensions.map(loadExtension)
+  );
+  const failedExtensionLoad = extensionLoadResults.find(
+    (result) => result.status === "rejected"
+  );
+  if (failedExtensionLoad) {
+    throw failedExtensionLoad.reason;
   }
 
   return extensions;
@@ -2840,15 +2841,14 @@ async function setBrowserDownloadBehavior(options = {}) {
   }
 
   await fs.promises.mkdir(downloadPath, { recursive: true });
-  const sessionTarget = page ? page.target() : browser.target();
-  const session = await sessionTarget.createCDPSession();
+  const pageSession = page ? await page.target().createCDPSession() : null;
 
   // Keep the CDP session alive for the lifetime of the caller's browser/page
   // connection. Extension-driven downloads regress if we detach immediately
   // after configuring download behavior.
   if (page) {
     try {
-      await session.send("Page.setDownloadBehavior", {
+      await pageSession.send("Page.setDownloadBehavior", {
         behavior: "allow",
         downloadPath,
       });
@@ -2866,7 +2866,10 @@ async function setBrowserDownloadBehavior(options = {}) {
   }
 
   try {
-    await session.send("Browser.setDownloadBehavior", {
+    if (!browser) {
+      throw new Error("browser connection is unavailable");
+    }
+    await sendBrowserCommand(browser, "Browser.setDownloadBehavior", {
       behavior: "allow",
       downloadPath,
     });
@@ -3093,30 +3096,30 @@ async function closeExistingTabs(browser) {
 
 async function resolvePageByTargetId(browser, targetId, timeoutMs = 0) {
   const deadline = Date.now() + Math.max(timeoutMs, 0);
-  let discoverySession = null;
+  let browserConnection = null;
 
-  async function ensureDiscoverySession() {
-    if (discoverySession) {
-      return discoverySession;
+  async function ensureBrowserDiscovery() {
+    if (browserConnection) {
+      return browserConnection;
     }
     try {
-      discoverySession = await browser.target().createCDPSession();
-      await discoverySession.send("Target.setDiscoverTargets", {
+      browserConnection = getBrowserConnection(browser);
+      await browserConnection.send("Target.setDiscoverTargets", {
         discover: true,
       });
     } catch (error) {
-      discoverySession = null;
+      browserConnection = null;
     }
-    return discoverySession;
+    return browserConnection;
   }
 
   async function targetIsKnownToCdp() {
-    const session = await ensureDiscoverySession();
-    if (!session) {
+    const connection = await ensureBrowserDiscovery();
+    if (!connection) {
       return false;
     }
     try {
-      const { targetInfos = [] } = await session.send("Target.getTargets");
+      const { targetInfos = [] } = await connection.send("Target.getTargets");
       return targetInfos.some(
         (targetInfo) =>
           targetInfo?.targetId === targetId &&
@@ -3139,7 +3142,7 @@ async function resolvePageByTargetId(browser, targetId, timeoutMs = 0) {
   }
 
   try {
-    await ensureDiscoverySession();
+    await ensureBrowserDiscovery();
 
     while (true) {
       const targets = browser.targets();
@@ -3188,11 +3191,8 @@ async function resolvePageByTargetId(browser, targetId, timeoutMs = 0) {
       await sleep(100);
     }
   } finally {
-    if (discoverySession) {
-      try {
-        await discoverySession.detach();
-      } catch (error) {}
-    }
+    // The root connection is owned by `browser` and disconnected by its caller.
+    browserConnection = null;
   }
 }
 
@@ -3308,16 +3308,12 @@ async function openTabInChromeSession(options = {}) {
         try {
           targetId = await withTimeout(
             async () => {
-              const browserSession = await browser.target().createCDPSession();
-              try {
-                const created = await browserSession.send("Target.createTarget", {
-                  url: "about:blank",
-                  background: true,
-                });
-                return created.targetId;
-              } finally {
-                await browserSession.detach().catch(() => {});
-              }
+              const created = await sendBrowserCommand(
+                browser,
+                "Target.createTarget",
+                { url: "about:blank", background: true }
+              );
+              return created.targetId;
             },
             remainingMs,
             `Timed out creating new page after ${remainingMs}ms`
@@ -3328,14 +3324,11 @@ async function openTabInChromeSession(options = {}) {
           return { targetId };
         } catch (error) {
           if (targetId) {
-            let cleanupSession = null;
             try {
-              cleanupSession = await browser.target().createCDPSession();
-              await cleanupSession.send("Target.closeTarget", { targetId });
+              await sendBrowserCommand(browser, "Target.closeTarget", {
+                targetId,
+              });
             } catch (closeError) {}
-            if (cleanupSession) {
-              await cleanupSession.detach().catch(() => {});
-            }
           }
           throw error;
         }
@@ -3370,12 +3363,16 @@ async function closeTabInChromeSession(options = {}) {
       connectOptions: { defaultViewport: null },
     },
     async (browser) => {
-      const session = await browser.target().createCDPSession();
-      const { targetInfos } = await session.send("Target.getTargets");
+      const { targetInfos } = await sendBrowserCommand(
+        browser,
+        "Target.getTargets"
+      );
       if (!targetInfos.some((target) => target.targetId === targetId)) {
         return false;
       }
-      const result = await session.send("Target.closeTarget", { targetId });
+      const result = await sendBrowserCommand(browser, "Target.closeTarget", {
+        targetId,
+      });
       return result.success;
     }
   );
@@ -3777,8 +3774,7 @@ async function closeBrowserInChromeSession(options = {}) {
             defaultViewport: null,
             protocolTimeout: Math.max(1, remainingCdpMs()),
           });
-          const session = await browser.target().createCDPSession();
-          await session.send("Browser.close");
+          await sendBrowserCommand(browser, "Browser.close");
         },
         Math.max(1, remainingCdpMs()),
         `Timed out closing browser at ${cdpUrl}`
@@ -4193,8 +4189,7 @@ async function getCookiesViaCdp(port, options = {}) {
       browserWSEndpoint,
     },
     async (browser) => {
-      const session = await browser.target().createCDPSession();
-      const result = await session.send("Storage.getCookies");
+      const result = await sendBrowserCommand(browser, "Storage.getCookies");
       return result?.cookies || [];
     }
   );
@@ -4241,6 +4236,8 @@ module.exports = {
   resolvePuppeteerModule,
   connectToBrowserEndpoint,
   withConnectedBrowser,
+  getBrowserConnection,
+  sendBrowserCommand,
   closeExistingTabs,
   getExtensionPaths,
   waitForExtensionTarget,

--- a/abx_plugins/plugins/chrome/tests/test_chrome_test_helpers.py
+++ b/abx_plugins/plugins/chrome/tests/test_chrome_test_helpers.py
@@ -490,7 +490,7 @@ def test_only_archivewebpage_export_enables_browser_download_events():
         script.relative_to(plugins_dir)
         for script in plugins_dir.glob("*/*.js")
         if script != CHROME_UTILS
-        and 'session.send("Browser.setDownloadBehavior"' in script.read_text()
+        and '"Browser.setDownloadBehavior"' in script.read_text()
     ]
 
     assert callers == [Path("archivewebpage/on_Snapshot__65_archivewebpage_stop.js")]

--- a/abx_plugins/plugins/ublock/on_CrawlSetup__95_ublock_config.js
+++ b/abx_plugins/plugins/ublock/on_CrawlSetup__95_ublock_config.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S abxpkg run --script --deps-from=../chrome/config.json:required_binaries,./config.json:required_binaries node
+// /// script
+// ///
+/**
+ * Keep uBlock's subresource filtering without allowing it to replace the page
+ * that ArchiveBox is recording.
+ *
+ * uBlock Origin Lite enables strict blocking by default. A strict-blocked
+ * main-frame navigation is redirected to the extension's strictblock.html,
+ * which makes ArchiveWeb.page correctly detach from the now non-web tab. The
+ * setting is browser-global, so configure it once after the crawl browser and
+ * extensions are ready, before any snapshot hooks can create recordings.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const {
+  PROCESS_EXIT_SKIPPED,
+  ensureNodeModuleResolution,
+  getEnv,
+  getEnvBool,
+  loadConfig,
+} = require("../base/utils.js");
+
+const hookConfig = loadConfig();
+const CRAWL_DIR = path.resolve((hookConfig.CRAWL_DIR || ".").trim());
+const CHROME_SESSION_DIR = path.join(CRAWL_DIR, "chrome");
+const OUTPUT_DIR = path.join(CRAWL_DIR, path.basename(__dirname));
+fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+process.chdir(OUTPUT_DIR);
+
+async function main() {
+  if (!getEnvBool("UBLOCK_ENABLED", true)) {
+    process.exit(PROCESS_EXIT_SKIPPED);
+  }
+  if (getEnv("CHROME_ISOLATION", "crawl").toLowerCase() === "snapshot") {
+    process.exit(PROCESS_EXIT_SKIPPED);
+  }
+
+  ensureNodeModuleResolution(module);
+  const { disableStrictBlocking } = require("./ublock_internal.js");
+  await disableStrictBlocking(CHROME_SESSION_DIR);
+  console.error(
+    "[+] Disabled uBlock top-level strict blocking; subresource filtering remains enabled",
+  );
+}
+
+main().catch((error) => {
+  console.error(error && (error.stack || error.message || String(error)));
+  process.exit(1);
+});

--- a/abx_plugins/plugins/ublock/on_Snapshot__11_ublock_config.js
+++ b/abx_plugins/plugins/ublock/on_Snapshot__11_ublock_config.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env -S abxpkg run --script --deps-from=../chrome/config.json:required_binaries,./config.json:required_binaries node
+// /// script
+// ///
+/** Configure the snapshot-owned browser before any recorder can navigate it. */
+
+const path = require("path");
+const {
+  PROCESS_EXIT_SKIPPED,
+  ensureNodeModuleResolution,
+  getEnv,
+  getEnvBool,
+  loadConfig,
+} = require("../base/utils.js");
+
+async function main() {
+  if (!getEnvBool("UBLOCK_ENABLED", true)) {
+    process.exit(PROCESS_EXIT_SKIPPED);
+  }
+  if (getEnv("CHROME_ISOLATION", "crawl").toLowerCase() !== "snapshot") {
+    process.exit(PROCESS_EXIT_SKIPPED);
+  }
+
+  ensureNodeModuleResolution(module);
+  const hookConfig = loadConfig();
+  const snapshotDir = path.resolve((hookConfig.SNAP_DIR || ".").trim());
+  const { disableStrictBlocking } = require("./ublock_internal.js");
+  await disableStrictBlocking(path.join(snapshotDir, "chrome"));
+  console.error(
+    "[+] Disabled uBlock top-level strict blocking; subresource filtering remains enabled",
+  );
+}
+
+main().catch((error) => {
+  console.error(error && (error.stack || error.message || String(error)));
+  process.exit(1);
+});

--- a/abx_plugins/plugins/ublock/tests/test_ublock.py
+++ b/abx_plugins/plugins/ublock/tests/test_ublock.py
@@ -19,11 +19,13 @@ from abx_plugins.plugins.base.testing import (
     parse_jsonl_records,
 )
 from abx_plugins.plugins.chrome.tests.chrome_test_helpers import (
+    CHROME_SNAPSHOT_LAUNCH_HOOK,
     chrome_extension_install_env,
     chrome_session,
     setup_test_env,
     launch_chromium_session,
     kill_chromium_session,
+    wait_for_chrome_session_state,
     wait_for_extensions_metadata,
 )
 
@@ -31,6 +33,7 @@ pytestmark = pytest.mark.usefixtures("ensure_chrome_test_prereqs")
 
 
 PLUGIN_DIR = Path(__file__).parent.parent
+SNAPSHOT_CONFIG_HOOK = PLUGIN_DIR / "on_Snapshot__11_ublock_config.js"
 SNAPSHOT_HOOK = PLUGIN_DIR / "on_Snapshot__12_ublock.daemon.bg.js"
 NAVIGATE_HOOK = PLUGIN_DIR.parent / "chrome" / "on_Snapshot__30_chrome_navigate.js"
 BASE_UTILS_JS = PLUGIN_DIR.parent / "base" / "utils.js"
@@ -165,6 +168,99 @@ def test_no_configuration_required():
 
         loaded = install_ublock_extension(env)
         assert loaded.loaded_abspath is not None
+
+
+def test_snapshot_owned_browser_disables_only_top_level_strict_blocking(tmp_path):
+    """Snapshot isolation must configure the browser that actually owns uBlock.
+
+    WHY: crawl setup has no browser to configure under CHROME_ISOLATION=snapshot.
+    The snapshot priority-11 hook must update uBlock's live worker before AWP's
+    priority-16 recording starts, without disabling normal filtering.
+    """
+    env = setup_test_env(tmp_path)
+    env.update(
+        {
+            "CHROME_HEADLESS": "true",
+            "CHROME_ISOLATION": "snapshot",
+        },
+    )
+    install_ublock_extension(env)
+    snapshot_dir = Path(env["SNAP_DIR"])
+    snapshot_chrome_dir = snapshot_dir / "chrome"
+    snapshot_chrome_dir.mkdir(parents=True)
+
+    launch_process = subprocess.Popen(
+        [
+            str(CHROME_SNAPSHOT_LAUNCH_HOOK),
+            "--url=https://example.com/",
+            "--snapshot-id=ublock-snapshot-owner",
+            "--crawl-id=ublock-snapshot-owner",
+        ],
+        cwd=snapshot_chrome_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    try:
+        wait_for_chrome_session_state(
+            snapshot_chrome_dir,
+            env=env,
+            require_browser_ready=True,
+        )
+        config = subprocess.run(
+            [str(SNAPSHOT_CONFIG_HOOK), "--url=https://example.com/"],
+            cwd=snapshot_dir,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+        assert config.returncode == 0, config.stderr
+
+        metadata = json.loads((snapshot_chrome_dir / "browser.json").read_text())
+        extension_id = next(
+            item["id"] for item in metadata["extensions"] if item["name"] == "ublock"
+        )
+        verify_script = f"""
+const chromeUtils = require({json.dumps(str(CHROME_UTILS_JS))});
+(async () => {{
+  const puppeteer = chromeUtils.resolvePuppeteerModule();
+  const browser = await chromeUtils.connectToBrowserEndpoint(
+    puppeteer,
+    {json.dumps((snapshot_chrome_dir / "cdp_url.txt").read_text().strip())}
+  );
+  try {{
+    const page = await browser.newPage();
+    await page.goto('chrome-extension://{extension_id}/dashboard.html');
+    const state = await page.evaluate(async () => {{
+      const {{ rulesetConfig }} = await chrome.storage.local.get('rulesetConfig');
+      return rulesetConfig;
+    }});
+    process.stdout.write(JSON.stringify(state));
+  }} finally {{
+    await browser.disconnect();
+  }}
+}})().catch((error) => {{
+  console.error(error.stack || error.message);
+  process.exit(1);
+}});
+"""
+        verified = subprocess.run(
+            [env["NODE_BINARY"], "-e", verify_script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        assert verified.returncode == 0, verified.stderr
+        ruleset_config = json.loads(verified.stdout)
+        assert ruleset_config["strictBlockMode"] is False
+        assert ruleset_config["enabledRulesets"], ruleset_config
+    finally:
+        if launch_process.poll() is None:
+            launch_process.send_signal(signal.SIGTERM)
+        launch_process.wait(timeout=20)
 
 
 def test_large_extension_size():

--- a/abx_plugins/plugins/ublock/ublock_internal.js
+++ b/abx_plugins/plugins/ublock/ublock_internal.js
@@ -1,0 +1,60 @@
+const {
+  connectToBrowserEndpoint,
+  findExtensionMetadataByName,
+  resolvePuppeteerModule,
+  waitForChromeSessionState,
+} = require("../chrome/chrome_utils.js");
+
+async function disableStrictBlocking(chromeSessionDir, timeoutMs = 30000) {
+  const chromeSession = await waitForChromeSessionState(chromeSessionDir, {
+    timeoutMs,
+    requireBrowserReady: true,
+  });
+  if (!chromeSession?.cdpUrl) {
+    throw new Error(`Chrome session is not ready in ${chromeSessionDir}`);
+  }
+
+  const extension = findExtensionMetadataByName(
+    chromeSession.extensions || [],
+    "ublock",
+  );
+  if (!extension?.id) {
+    throw new Error("uBlock extension ID is missing from browser.json");
+  }
+
+  const browser = await connectToBrowserEndpoint(
+    resolvePuppeteerModule(),
+    chromeSession.cdpUrl,
+    { defaultViewport: null },
+  );
+  let settingsPage = null;
+  try {
+    settingsPage = await browser.newPage();
+    await settingsPage.goto(
+      `chrome-extension://${extension.id}/dashboard.html`,
+      { waitUntil: "domcontentloaded", timeout: Math.min(timeoutMs, 10000) },
+    );
+
+    const configured = await settingsPage.evaluate(async () => {
+      // Use the same public message consumed by uBlock's settings checkbox.
+      // This updates both the live DNR session rules and persisted config;
+      // writing chrome.storage alone would leave the running worker unchanged.
+      await chrome.runtime.sendMessage({
+        what: "setStrictBlockMode",
+        state: false,
+      });
+      const { rulesetConfig } = await chrome.storage.local.get("rulesetConfig");
+      return rulesetConfig?.strictBlockMode === false;
+    });
+    if (!configured) {
+      throw new Error("uBlock did not persist strictBlockMode=false");
+    }
+  } finally {
+    if (settingsPage) {
+      await settingsPage.close({ runBeforeUnload: false }).catch(() => {});
+    }
+    await browser.disconnect();
+  }
+}
+
+module.exports = { disableStrictBlocking };

--- a/tests/test_archivewebpage_concurrent_collections.py
+++ b/tests/test_archivewebpage_concurrent_collections.py
@@ -132,21 +132,83 @@ def _stop_tab_process(tab_process: subprocess.Popen[str]) -> None:
             handle.close()
 
 
-def test_wacz_publication_observer_owns_all_fs_watch_outcomes() -> None:
-    """Keep rare watcher outcomes inside the hook's normal failure boundary.
+def test_wacz_publication_observer_owns_real_fs_events_and_errors(tmp_path) -> None:
+    """Observe the exact published file and keep watcher errors awaitable.
 
-    WHY: ``fs.watch`` documents that ``filename`` can be absent, and its
-    ``FSWatcher`` can emit ``error`` after construction.  These branches are
-    supplied by the operating-system watcher backend and cannot be induced
-    portably without faking that backend.  Assert the production wiring
-    directly: filename-less notifications must stat the one exact expected
-    WACZ, while watcher errors must reject the owned publication promise
-    instead of becoming an uncaught process exception.
+    WHY: Chrome's completed event can precede the final rename, ``fs.watch``
+    filenames are optional, and a watcher backend can fail after startup. The
+    observer must therefore stat only the exact expected path on every real
+    filesystem event, ignore unrelated publications, and expose filesystem
+    failures through its promise rather than an unhandled EventEmitter error.
     """
-    source = ARCHIVEWEBPAGE_STOP_HOOK.read_text()
+    env = setup_test_env(tmp_path)
+    snapshot_dir = tmp_path / "publication-observer-snapshot"
+    output_dir = snapshot_dir / "archivewebpage"
+    output_dir.mkdir(parents=True)
+    watch_dir = tmp_path / "chrome-downloads"
+    script = r"""
+const fs = require("fs");
+const path = require("path");
+const stopHook = require(process.argv[1]);
+const watchDir = process.argv[2];
 
-    assert "if (filename && filename.toString() !== expectedName) return;" in source
-    assert 'watcher.on("error", (error) => finish(reject, error));' in source
+(async () => {
+  if (typeof stopHook.observePublishedFile !== "function") {
+    throw new Error("stop hook does not export observePublishedFile");
+  }
+  fs.mkdirSync(watchDir, { recursive: true });
+  const expectedPath = path.join(watchDir, "expected.wacz");
+  const publication = stopHook.observePublishedFile(expectedPath, 5000);
+  let settled = false;
+  publication.promise.finally(() => { settled = true; });
+
+  fs.writeFileSync(path.join(watchDir, "unrelated.wacz"), "wrong artifact");
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  if (settled) throw new Error("unrelated file settled exact WACZ observer");
+
+  fs.writeFileSync(expectedPath, "real archivewebpage output");
+  const stat = await publication.promise;
+  if (stat.size !== Buffer.byteLength("real archivewebpage output")) {
+    throw new Error(`observer returned wrong WACZ size: ${stat.size}`);
+  }
+
+  const failed = stopHook.observePublishedFile(
+    path.join(watchDir, "missing-directory", "never.wacz"),
+    5000
+  );
+  try {
+    await failed.promise;
+    throw new Error("missing watch directory unexpectedly succeeded");
+  } catch (error) {
+    if (!error || !["ENOENT", "ERR_FS_WATCHER_INIT_FAILED"].includes(error.code)) {
+      throw error;
+    }
+  } finally {
+    failed.close();
+  }
+  process.stdout.write("observer behavior verified");
+})().catch((error) => {
+  console.error(error && (error.stack || error.message || String(error)));
+  process.exit(1);
+});
+"""
+    result = subprocess.run(
+        [
+            env["NODE_BINARY"],
+            "-e",
+            script,
+            str(ARCHIVEWEBPAGE_STOP_HOOK),
+            str(watch_dir),
+        ],
+        cwd=output_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "observer behavior verified"
 
 
 @pytest.fixture

--- a/tests/test_archivewebpage_concurrent_collections.py
+++ b/tests/test_archivewebpage_concurrent_collections.py
@@ -3,6 +3,7 @@ import shutil
 import signal
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TypedDict
 
@@ -24,6 +25,13 @@ pytestmark = pytest.mark.usefixtures("ensure_chrome_test_prereqs")
 ARCHIVEWEBPAGE_PLUGIN_DIR = CHROME_UTILS.parent.parent / "archivewebpage"
 ARCHIVEWEBPAGE_START_HOOK = (
     ARCHIVEWEBPAGE_PLUGIN_DIR / "on_Snapshot__16_archivewebpage_start.js"
+)
+ARCHIVEWEBPAGE_STOP_HOOK = (
+    ARCHIVEWEBPAGE_PLUGIN_DIR / "on_Snapshot__65_archivewebpage_stop.js"
+)
+CHROME_NAVIGATE_HOOK = CHROME_UTILS.parent / "on_Snapshot__30_chrome_navigate.js"
+UBLOCK_CONFIG_HOOK = (
+    CHROME_UTILS.parent.parent / "ublock" / "on_CrawlSetup__95_ublock_config.js"
 )
 AWP_INTERNAL = ARCHIVEWEBPAGE_PLUGIN_DIR / "awp_internal.js"
 
@@ -64,6 +72,139 @@ def _run_start_hook(
         timeout=60,
         env=env,
     )
+
+
+def _run_navigate_hook(
+    snapshot_dir: Path,
+    env: dict[str, str],
+    url: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(CHROME_NAVIGATE_HOOK), f"--url={url}"],
+        cwd=snapshot_dir / "chrome",
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+
+
+def _run_stop_hook(
+    snapshot_dir: Path,
+    env: dict[str, str],
+    url: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(ARCHIVEWEBPAGE_STOP_HOOK), f"--url={url}"],
+        cwd=snapshot_dir / "archivewebpage",
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+
+
+def _run_ublock_config_hook(
+    crawl_chrome_dir: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(UBLOCK_CONFIG_HOOK), "--url=https://example.com/"],
+        cwd=crawl_chrome_dir.parent,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+
+
+def _stop_tab_process(tab_process: subprocess.Popen[str]) -> None:
+    if tab_process.poll() is None:
+        tab_process.send_signal(signal.SIGTERM)
+    try:
+        tab_process.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        tab_process.kill()
+        tab_process.wait(timeout=5)
+    for attr in ("_stdout_handle", "_stderr_handle"):
+        handle = getattr(tab_process, attr, None)
+        if handle:
+            handle.close()
+
+
+@pytest.fixture
+def archivewebpage_crawl(
+    tmp_path,
+) -> Iterator[tuple[dict[str, str], Path, list[subprocess.Popen[str]]]]:
+    """Run the real shared-browser topology used by an ArchiveBox crawl."""
+    env = setup_test_env(tmp_path)
+    env.update(
+        {
+            "CHROME_HEADLESS": "true",
+            "CHROME_ISOLATION": "crawl",
+            "CHROME_KEEPALIVE": "false",
+        },
+    )
+    for plugin_name in ("archivewebpage", "ublock"):
+        plugin_dir = CHROME_UTILS.parent.parent / plugin_name
+        installed = install_required_binary_from_config(
+            plugin_dir,
+            plugin_name,
+            env=env,
+        )
+        assert installed.loaded_abspath is not None
+
+    crawl_chrome_dir = Path(env["CRAWL_DIR"]) / "chrome"
+    launch_process, _cdp_url = launch_chromium_session(
+        env,
+        crawl_chrome_dir,
+        "test-archivewebpage-lifecycle",
+    )
+    ublock_config = _run_ublock_config_hook(crawl_chrome_dir, env)
+    assert ublock_config.returncode == 0, (
+        "uBlock crawl configuration failed:\n"
+        f"stdout={ublock_config.stdout}\nstderr={ublock_config.stderr}"
+    )
+    tab_processes: list[subprocess.Popen[str]] = []
+    try:
+        yield env, crawl_chrome_dir, tab_processes
+    finally:
+        for tab_process in tab_processes:
+            _stop_tab_process(tab_process)
+        kill_chromium_session(launch_process, crawl_chrome_dir)
+
+
+def _start_snapshot_recording(
+    root: Path,
+    base_env: dict[str, str],
+    tab_processes: list[subprocess.Popen[str]],
+    *,
+    snapshot_id: str,
+    url: str,
+) -> tuple[Path, dict[str, str]]:
+    snapshot_dir = root / snapshot_id
+    chrome_dir = snapshot_dir / "chrome"
+    chrome_dir.mkdir(parents=True)
+    env = base_env | {"SNAP_DIR": str(snapshot_dir)}
+    tab_processes.append(
+        launch_snapshot_tab(
+            snapshot_chrome_dir=chrome_dir,
+            tab_env=env,
+            test_url=url,
+            snapshot_id=snapshot_id,
+            crawl_id="test-archivewebpage-lifecycle",
+        ),
+    )
+    start = _run_start_hook(snapshot_dir, env, url)
+    assert start.returncode == 0, (
+        f"AWP start failed for {url}:\nstdout={start.stdout}\nstderr={start.stderr}"
+    )
+    navigate = _run_navigate_hook(snapshot_dir, env, url)
+    assert navigate.returncode == 0, (
+        f"Chrome navigation failed for {url}:\n"
+        f"stdout={navigate.stdout}\nstderr={navigate.stderr}"
+    )
+    return snapshot_dir, env
 
 
 def _open_child_target(snapshot_chrome_dir: Path, env: dict[str, str]) -> str:
@@ -390,6 +531,136 @@ def _publish_child_snapshot_session(
         require_browser_ready=True,
         require_connectable=True,
     )
+
+
+def test_cowpig_recording_survives_overlapping_snapshot_lifecycles(
+    archivewebpage_crawl,
+    chrome_test_url,
+    tmp_path,
+):
+    """AWP must retain the exact Cowpig target until its stop hook completes.
+
+    WHY: the real depth=1 crawl lost this target while its tab-owner daemon was
+    still alive, then stop failed in Target.attachToTarget. Three sibling
+    snapshots were recording in the same crawl browser at that moment, so this
+    regression preserves that overlap and exercises the actual AWP/Chrome
+    hooks instead of manufacturing a closed target or protocol exception.
+    """
+    env, _crawl_chrome_dir, tab_processes = archivewebpage_crawl
+    cases = (
+        ("cowpig", "https://cowpig.github.io/about/"),
+        ("sibling-one", f"{chrome_test_url}#sibling-one"),
+        ("sibling-two", f"{chrome_test_url}#sibling-two"),
+        ("sibling-three", f"{chrome_test_url}#sibling-three"),
+    )
+    snapshots_root = tmp_path / "overlapping-snapshots"
+    with ThreadPoolExecutor(max_workers=len(cases)) as executor:
+        runs = list(
+            executor.map(
+                lambda case: _start_snapshot_recording(
+                    snapshots_root,
+                    env,
+                    tab_processes,
+                    snapshot_id=case[0],
+                    url=case[1],
+                ),
+                cases,
+            ),
+        )
+
+    cowpig_dir, cowpig_env = runs[0]
+    stop = _run_stop_hook(cowpig_dir, cowpig_env, cases[0][1])
+    assert stop.returncode == 0, (
+        "Cowpig AWP stop lost a live lifecycle-owned target:\n"
+        f"stdout={stop.stdout}\nstderr={stop.stderr}"
+    )
+    assert (cowpig_dir / "archivewebpage" / "archivewebpage.wacz").stat().st_size > 0
+
+
+def test_concurrent_stops_each_publish_their_exact_wacz(
+    archivewebpage_crawl,
+    tmp_path,
+):
+    """Two simultaneous AWP exports must not lose either completed download.
+
+    WHY: the real nicksweeting.com and nicksweeting.com/ snapshots reached the
+    stop hook 46ms apart. Chrome reported the second unique download complete,
+    but its expected file did not exist in the shared persona download dir.
+    These are the same two URLs, one browser, two tabs, two collections, and
+    concurrent real stop/export hooks that produced the ENOENT.
+    """
+    env, _crawl_chrome_dir, tab_processes = archivewebpage_crawl
+    cases = (
+        ("nicksweeting-no-slash", "https://nicksweeting.com"),
+        ("nicksweeting-slash", "https://nicksweeting.com/"),
+    )
+    snapshots_root = tmp_path / "concurrent-export-snapshots"
+    with ThreadPoolExecutor(max_workers=len(cases)) as executor:
+        runs = list(
+            executor.map(
+                lambda case: _start_snapshot_recording(
+                    snapshots_root,
+                    env,
+                    tab_processes,
+                    snapshot_id=case[0],
+                    url=case[1],
+                ),
+                cases,
+            ),
+        )
+        stop_inputs = (
+            (snapshot_dir, snapshot_env, case[1])
+            for case, (snapshot_dir, snapshot_env) in zip(cases, runs, strict=True)
+        )
+        stops = list(
+            executor.map(
+                lambda stop_input: _run_stop_hook(*stop_input),
+                stop_inputs,
+            ),
+        )
+
+    for case, run, stop in zip(cases, runs, stops, strict=True):
+        assert stop.returncode == 0, (
+            f"Concurrent AWP stop failed for {case[1]}:\n"
+            f"stdout={stop.stdout}\nstderr={stop.stderr}"
+        )
+        output = run[0] / "archivewebpage" / "archivewebpage.wacz"
+        assert output.stat().st_size > 0
+
+
+def test_ublock_never_replaces_the_recorded_page_with_strictblock(
+    archivewebpage_crawl,
+    tmp_path,
+):
+    """uBlock must not replace AWP's recorded top-level document.
+
+    WHY: the real Cloudflare beacon snapshot began recording successfully, but
+    uBlock replaced its top-level navigation with strictblock.html. AWP then
+    reported recording=false for the same tab and exact collection, and the
+    stop hook failed without exporting the already captured collection.
+    """
+    env, _crawl_chrome_dir, tab_processes = archivewebpage_crawl
+    url = (
+        "https://static.cloudflareinsights.com/beacon.min.js/"
+        "v3d52b47920f24c319d37e2661827c42b1787588026925"
+    )
+    snapshot_dir, snapshot_env = _start_snapshot_recording(
+        tmp_path / "strictblock-snapshots",
+        env,
+        tab_processes,
+        snapshot_id="cloudflare-beacon",
+        url=url,
+    )
+    navigation = json.loads((snapshot_dir / "chrome" / "navigation.json").read_text())
+    assert not navigation["finalUrl"].startswith("chrome-extension://"), navigation
+    assert "/strictblock.html#" not in navigation["finalUrl"], navigation
+
+    stop = _run_stop_hook(snapshot_dir, snapshot_env, url)
+    assert stop.returncode == 0, (
+        "AWP discarded the exact collection after uBlock strict-blocked navigation:\n"
+        f"stdout={stop.stdout}\nstderr={stop.stderr}"
+    )
+    assert (snapshot_dir / "archivewebpage" / "archivewebpage.wacz").stat().st_size > 0
 
 
 def test_start_reassigns_inherited_tab_recorder_to_its_requested_collection(

--- a/tests/test_archivewebpage_concurrent_collections.py
+++ b/tests/test_archivewebpage_concurrent_collections.py
@@ -142,23 +142,20 @@ def test_wacz_publication_observer_owns_real_fs_events_and_errors(tmp_path) -> N
     failures through its promise rather than an unhandled EventEmitter error.
     """
     env = setup_test_env(tmp_path)
-    snapshot_dir = tmp_path / "publication-observer-snapshot"
-    output_dir = snapshot_dir / "archivewebpage"
-    output_dir.mkdir(parents=True)
     watch_dir = tmp_path / "chrome-downloads"
     script = r"""
 const fs = require("fs");
 const path = require("path");
-const stopHook = require(process.argv[1]);
+const awpInternal = require(process.argv[1]);
 const watchDir = process.argv[2];
 
 (async () => {
-  if (typeof stopHook.observePublishedFile !== "function") {
-    throw new Error("stop hook does not export observePublishedFile");
+  if (typeof awpInternal.observePublishedFile !== "function") {
+    throw new Error("awp_internal does not export observePublishedFile");
   }
   fs.mkdirSync(watchDir, { recursive: true });
   const expectedPath = path.join(watchDir, "expected.wacz");
-  const publication = stopHook.observePublishedFile(expectedPath, 5000);
+  const publication = awpInternal.observePublishedFile(expectedPath, 5000);
   let settled = false;
   publication.promise.finally(() => { settled = true; });
 
@@ -172,7 +169,7 @@ const watchDir = process.argv[2];
     throw new Error(`observer returned wrong WACZ size: ${stat.size}`);
   }
 
-  const failed = stopHook.observePublishedFile(
+  const failed = awpInternal.observePublishedFile(
     path.join(watchDir, "missing-directory", "never.wacz"),
     5000
   );
@@ -197,10 +194,10 @@ const watchDir = process.argv[2];
             env["NODE_BINARY"],
             "-e",
             script,
-            str(ARCHIVEWEBPAGE_STOP_HOOK),
+            str(AWP_INTERNAL),
             str(watch_dir),
         ],
-        cwd=output_dir,
+        cwd=tmp_path,
         capture_output=True,
         text=True,
         timeout=30,

--- a/tests/test_archivewebpage_concurrent_collections.py
+++ b/tests/test_archivewebpage_concurrent_collections.py
@@ -132,6 +132,23 @@ def _stop_tab_process(tab_process: subprocess.Popen[str]) -> None:
             handle.close()
 
 
+def test_wacz_publication_observer_owns_all_fs_watch_outcomes() -> None:
+    """Keep rare watcher outcomes inside the hook's normal failure boundary.
+
+    WHY: ``fs.watch`` documents that ``filename`` can be absent, and its
+    ``FSWatcher`` can emit ``error`` after construction.  These branches are
+    supplied by the operating-system watcher backend and cannot be induced
+    portably without faking that backend.  Assert the production wiring
+    directly: filename-less notifications must stat the one exact expected
+    WACZ, while watcher errors must reject the owned publication promise
+    instead of becoming an uncaught process exception.
+    """
+    source = ARCHIVEWEBPAGE_STOP_HOOK.read_text()
+
+    assert "if (filename && filename.toString() !== expectedName) return;" in source
+    assert 'watcher.on("error", (error) => finish(reject, error));' in source
+
+
 @pytest.fixture
 def archivewebpage_crawl(
     tmp_path,
@@ -793,16 +810,6 @@ def test_start_reassigns_inherited_tab_recorder_to_its_requested_collection(
         assert first_status_after_reassignment["collId"] == first_state["collId"]
     finally:
         if first_tab_process is not None:
-            if first_tab_process.poll() is None:
-                first_tab_process.send_signal(signal.SIGTERM)
-            try:
-                first_tab_process.wait(timeout=20)
-            except subprocess.TimeoutExpired:
-                first_tab_process.kill()
-                first_tab_process.wait(timeout=5)
-            for attr in ("_stdout_handle", "_stderr_handle"):
-                handle = getattr(first_tab_process, attr, None)
-                if handle:
-                    handle.close()
+            _stop_tab_process(first_tab_process)
         if launch_process is not None:
             kill_chromium_session(launch_process, crawl_chrome_dir)


### PR DESCRIPTION
## What

\n\nFixes the three ArchiveWebPage stop failures reproduced by the full depth-1 sweeting.me crawl:\n\n- Cowpig: transient Puppeteer synthetic browser target was used for root Target/Browser CDP commands and disappeared under overlapping clients\n- Nicks: Browser.downloadProgress completed raced the final filesystem publication of the WACZ\n- Cloudflare Insights: uBlock Origin Lite strict blocking replaced the recorded HTTP page with an extension page\n\nRoot Browser/Target/Storage/Extensions commands now use the browser connection, WACZ export waits for both the exact CDP download and exact non-empty published file, and uBlock disables only top-level strict blocking through its supported runtime API while keeping subresource filtering enabled.\n\n## Red regressions\n\nEach production failure was reproduced first with real Chrome, real hooks, and the real ArchiveWebPage/uBlock extensions:\n\n- test_cowpig_recording_survives_overlapping_snapshot_lifecycles\n- test_concurrent_stops_each_publish_their_exact_wacz\n- test_ublock_never_replaces_the_recorded_page_with_strictblock\n\nThe watcher edge cases also have a real filesystem regression: unrelated publication stays pending, the exact WACZ resolves with its real size, and an actual watcher initialization failure rejects through the awaited promise.\n\n## Verification\n\n- full fresh Docker archivebox add --depth=1 https://sweeting.me/: 75/75 AWP exports succeeded, zero AWP failures\n- Cowpig, Cloudflare, all three Nicks snapshots, and all three YouTube snapshots produced WACZ files\n- all 75 WACZ ZIP integrity checks passed\n- static export: 76 pages, 75 JSONL records, 11,285 local links checked, zero missing targets\n- tests/test_archivewebpage_concurrent_collections.py: 5 passed\n- Chrome helper and uBlock suites: 38 passed before final focused cleanup\n- three repeated Nicks concurrent-stop stress runs passed\n- prek on all changed files passed