### PR TITLE
Deduplicate hashed snapshot files with hardlinks

### DIFF
--- a/abx_plugins/plugins/hashes/on_Snapshot__93_hashes.py
+++ b/abx_plugins/plugins/hashes/on_Snapshot__93_hashes.py
@@ -13,6 +13,7 @@ import sys
 import os
 import json
 import hashlib
+import stat
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import Any
@@ -126,6 +127,55 @@ def create_hashes(snapshot_dir: Path) -> dict[str, Any]:
     }
 
 
+def hardlink_duplicates(snapshot_dir: Path, files: list[dict[str, Any]]) -> None:
+    """Share proven-identical bytes without changing ArchiveBox's public paths."""
+    originals: dict[tuple[str, int], Path] = {}
+    for index, item in enumerate(files):
+        key = (str(item["hash"]), int(item["size"]))
+        # Empty files reclaim nothing; a zero digest means hashing failed, not equality.
+        if key[1] <= 0 or key[0] == "0" * 64:
+            continue
+        path = snapshot_dir / item["path"]
+        source = originals.setdefault(key, path)
+        if source == path:
+            continue
+        temp_path = path.parent / f".abx-hardlink-{os.getpid()}-{index}"
+        # Never clean up a pre-existing path if link creation fails with EEXIST.
+        temp_created = False
+        try:
+            source_stat, path_stat = source.stat(), path.stat()
+            # Hardlinks share inode metadata, so differing metadata must remain separate.
+            if (
+                os.path.samestat(source_stat, path_stat)
+                or source_stat.st_dev != path_stat.st_dev
+                or not stat.S_ISREG(source_stat.st_mode)
+                or not stat.S_ISREG(path_stat.st_mode)
+                or source_stat.st_size != key[1]
+                or path_stat.st_size != key[1]
+                or (source_stat.st_mode, source_stat.st_uid, source_stat.st_gid)
+                != (path_stat.st_mode, path_stat.st_uid, path_stat.st_gid)
+            ):
+                continue
+            # A sibling link plus atomic replace keeps the public path present on every failure.
+            os.link(source, temp_path)
+            temp_created = True
+            # Late writers can stale the manifest; never merge a file that changed meanwhile.
+            if source.stat().st_mtime_ns != source_stat.st_mtime_ns:
+                continue
+            if path.stat().st_mtime_ns != path_stat.st_mtime_ns:
+                continue
+            os.replace(temp_path, path)
+        except OSError:
+            # TODO: Decide whether to try a symlink before giving up when hardlinks are unavailable.
+            pass
+        finally:
+            if temp_created:
+                try:
+                    temp_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+
+
 def format_output_str(total_size: int, root_hash: str | None) -> str:
     total_size_mb = total_size / 1_000_000
     short_hash = (root_hash or "")[:12]
@@ -172,6 +222,7 @@ def main(url: str):
 
         # Generate Merkle tree
         merkle_data = create_hashes(snapshot_dir)
+        hardlink_duplicates(snapshot_dir, merkle_data["files"])
 
         # Write output
         with open(output_path, "w", encoding="utf-8") as f:

--- a/abx_plugins/plugins/hashes/tests/test_hashes.py
+++ b/abx_plugins/plugins/hashes/tests/test_hashes.py
@@ -6,6 +6,7 @@ Tests the real merkle tree generation with actual files.
 
 import json
 import os
+import runpy
 import subprocess
 import tempfile
 from pathlib import Path
@@ -91,6 +92,84 @@ class TestHashesPlugin:
             # Should succeed (exit 0) but skip
             assert result.returncode == 0
             assert "skipped" in result.stdout
+
+    def test_hashes_hardlinks_exact_duplicate_files(self, tmp_path: Path):
+        """Exact duplicate outputs should keep both paths while sharing one inode."""
+        snap_dir = tmp_path / "snap"
+        output_dir = snap_dir / "hashes"
+        first = snap_dir / "responses" / "image.png"
+        duplicate = snap_dir / "wget" / "image.png"
+        for path in (output_dir, first.parent, duplicate.parent):
+            path.mkdir(parents=True)
+        first.write_bytes(b"same archived image" * 1024)
+        duplicate.write_bytes(first.read_bytes())
+
+        result = subprocess.run(
+            [str(HASHES_HOOK), "--url=https://example.com"],
+            capture_output=True,
+            text=True,
+            cwd=output_dir,
+            env={**os.environ, "HASHES_ENABLED": "true", "SNAP_DIR": str(snap_dir)},
+            timeout=30,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert first.read_bytes() == duplicate.read_bytes()
+        assert first.stat().st_ino == duplicate.stat().st_ino
+        assert {
+            row["path"]
+            for row in json.loads((output_dir / "hashes.json").read_text())["files"]
+        } >= {
+            "responses/image.png",
+            "wget/image.png",
+        }
+
+    def test_hardlink_failure_keeps_both_files(self, tmp_path: Path):
+        """A filesystem refusing hardlinks must leave both original paths intact."""
+        snap_dir = tmp_path / "snap"
+        output_dir = snap_dir / "hashes"
+        first = snap_dir / "responses" / "image.png"
+        duplicate = snap_dir / "readonly" / "image.png"
+        for path in (output_dir, first.parent, duplicate.parent):
+            path.mkdir(parents=True)
+        first.write_bytes(b"same archived image")
+        duplicate.write_bytes(first.read_bytes())
+        old_cwd = Path.cwd()
+        old_snap_dir = os.environ.get("SNAP_DIR")
+        os.environ["SNAP_DIR"] = str(snap_dir)
+        try:
+            hardlink_duplicates = runpy.run_path(
+                str(HASHES_HOOK),
+                run_name="hashes_hook_test",
+            )["hardlink_duplicates"]
+        finally:
+            os.chdir(old_cwd)
+            if old_snap_dir is None:
+                os.environ.pop("SNAP_DIR")
+            else:
+                os.environ["SNAP_DIR"] = old_snap_dir
+
+        blocker = duplicate.parent / f".abx-hardlink-{os.getpid()}-1"
+        blocker.mkdir()
+        hardlink_duplicates(
+            snap_dir,
+            [
+                {
+                    "path": str(first.relative_to(snap_dir)),
+                    "hash": "a" * 64,
+                    "size": first.stat().st_size,
+                },
+                {
+                    "path": str(duplicate.relative_to(snap_dir)),
+                    "hash": "a" * 64,
+                    "size": duplicate.stat().st_size,
+                },
+            ],
+        )
+
+        assert first.read_bytes() == duplicate.read_bytes() == b"same archived image"
+        assert first.stat().st_ino != duplicate.stat().st_ino
+        assert blocker.is_dir()
 
     def test_hashes_merges_extra_context_into_archive_result(self):
         """Hashes hook should merge orchestrator-provided extra context into JSONL output."""


### PR DESCRIPTION
## Summary
- reuse the hashes manifest to hardlink exact duplicate snapshot files
- create a temporary sibling link and atomically replace the duplicate path
- silently skip unsupported hardlinks while preserving both original paths
- document the safety rationale and deferred symlink decision

## Verification
- uv run --no-sync --no-sources pytest abx_plugins/plugins/hashes/tests/test_hashes.py -q
- uv run --no-sync --no-sources ruff check abx_plugins/plugins/hashes/on_Snapshot__93_hashes.py abx_plugins/plugins/hashes/tests/test_hashes.py
- uv run --no-sync --no-sources pyright abx_plugins/plugins/hashes/on_Snapshot__93_hashes.py
- commit hooks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates exact duplicate snapshot files by hardlinking them through the hashes manifest, so repeated content no longer wastes disk space while both public paths stay intact.

**Details**
- Creates a temporary sibling link and atomically replaces the duplicate path, so the original path is always present on failure.
- Silently skips filesystems that don't support hardlinks and leaves both files untouched.
- Adds tests covering inode sharing for duplicates and the hardlink failure fallback.

<sup>Written for commit 0b9b02ba78b521fe44bb29e33cdc91117ffd2a6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

