### PR TITLE
Make plugin manifests product-neutral catalog metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ without symlinks or environment-variable tricks.
 Each plugin lives under `plugins/<name>/` and may include:
 
 - `config.json` config schema
+- optional generic catalog metadata in `config.json`: `category`, `display_order`, `hidden`, and `x-auto-run` (set false for hooks that require explicit host selection)
 - `config.json > required_binaries` binary dependency declarations (optional)
 - `on_CrawlSetup__...` crawl setup hook scripts (optional) - shared setup/process startup, emit no stdout JSONL records
 - `on_Snapshot__...` per-snapshot hooks - emit `ArchiveResult` and may also emit `Snapshot` / `Tag`

--- a/abx_plugins/plugins/accessibility/config.json
+++ b/abx_plugins/plugins/accessibility/config.json
@@ -28,5 +28,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for accessibility capture in seconds"
     }
-  }
+  },
+  "category": "metadata",
+  "display_order": 50
 }

--- a/abx_plugins/plugins/archivedotorg/config.json
+++ b/abx_plugins/plugins/archivedotorg/config.json
@@ -27,5 +27,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for archive.org submission in seconds"
     }
-  }
+  },
+  "category": "main",
+  "display_order": 60
 }

--- a/abx_plugins/plugins/archivewebpage/config.json
+++ b/abx_plugins/plugins/archivewebpage/config.json
@@ -64,5 +64,7 @@
       "default": "abx-dl",
       "description": "Collection title to use when AWP has no default collection yet"
     }
-  }
+  },
+  "category": "main",
+  "display_order": 80
 }

--- a/abx_plugins/plugins/base/config.json
+++ b/abx_plugins/plugins/base/config.json
@@ -106,5 +106,6 @@
       "description": "Optional V8 coverage output directory for Node.js hooks",
       "x-scope": "crawl_execution"
     }
-  }
+  },
+  "hidden": true
 }

--- a/abx_plugins/plugins/chrome/config.json
+++ b/abx_plugins/plugins/chrome/config.json
@@ -273,5 +273,7 @@
       "x-fallback": "CHECK_SSL_VALIDITY",
       "description": "Whether to verify SSL certificates (disable for self-signed certs)"
     }
-  }
+  },
+  "category": "page_setup",
+  "display_order": 10
 }

--- a/abx_plugins/plugins/chrome_mhtml/config.json
+++ b/abx_plugins/plugins/chrome_mhtml/config.json
@@ -29,5 +29,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for browser-generated MHTML capture in seconds"
     }
-  }
+  },
+  "category": "main",
+  "display_order": 70
 }

--- a/abx_plugins/plugins/chrome_screencast/config.json
+++ b/abx_plugins/plugins/chrome_screencast/config.json
@@ -44,5 +44,7 @@
       "maximum": 1,
       "description": "CDP screenshot clip scale for live preview frames"
     }
-  }
+  },
+  "category": "media",
+  "display_order": 30
 }

--- a/abx_plugins/plugins/claudechrome/config.json
+++ b/abx_plugins/plugins/claudechrome/config.json
@@ -65,5 +65,7 @@
       "x-sensitive": true,
       "description": "Anthropic API key for Claude for Chrome authentication"
     }
-  }
+  },
+  "category": "page_setup",
+  "display_order": 70
 }

--- a/abx_plugins/plugins/claudecode/config.json
+++ b/abx_plugins/plugins/claudecode/config.json
@@ -85,5 +85,7 @@
       "minimum": 1,
       "description": "Maximum number of agentic turns per invocation"
     }
-  }
+  },
+  "category": "postprocessing",
+  "display_order": 70
 }

--- a/abx_plugins/plugins/claudecodecleanup/config.json
+++ b/abx_plugins/plugins/claudecodecleanup/config.json
@@ -48,5 +48,7 @@
       "x-fallback": "CLAUDECODE_MAX_TURNS",
       "description": "Maximum number of agentic turns for cleanup"
     }
-  }
+  },
+  "category": "postprocessing",
+  "display_order": 80
 }

--- a/abx_plugins/plugins/claudecodeextract/config.json
+++ b/abx_plugins/plugins/claudecodeextract/config.json
@@ -48,5 +48,7 @@
       "x-fallback": "CLAUDECODE_MAX_TURNS",
       "description": "Maximum number of agentic turns for extraction"
     }
-  }
+  },
+  "category": "postprocessing",
+  "display_order": 90
 }

--- a/abx_plugins/plugins/consolelog/config.json
+++ b/abx_plugins/plugins/consolelog/config.json
@@ -28,5 +28,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for console log capture in seconds"
     }
-  }
+  },
+  "category": "metadata",
+  "display_order": 60
 }

--- a/abx_plugins/plugins/defuddle/config.json
+++ b/abx_plugins/plugins/defuddle/config.json
@@ -69,5 +69,7 @@
       ],
       "description": "Extra arguments to append to Defuddle command"
     }
-  }
+  },
+  "category": "text",
+  "display_order": 30
 }

--- a/abx_plugins/plugins/dns/config.json
+++ b/abx_plugins/plugins/dns/config.json
@@ -28,5 +28,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for DNS recording in seconds"
     }
-  }
+  },
+  "category": "metadata",
+  "display_order": 80
 }

--- a/abx_plugins/plugins/dom/config.json
+++ b/abx_plugins/plugins/dom/config.json
@@ -28,5 +28,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for DOM capture in seconds"
     }
-  }
+  },
+  "category": "main",
+  "display_order": 10
 }

--- a/abx_plugins/plugins/favicon/config.json
+++ b/abx_plugins/plugins/favicon/config.json
@@ -32,5 +32,7 @@
       "default": "https://www.google.com/s2/favicons?domain={}&format=ico",
       "description": "Fallback favicon provider when not found via chrome tab. {} will be replaced with the domain."
     }
-  }
+  },
+  "category": "metadata",
+  "display_order": 20
 }

--- a/abx_plugins/plugins/forumdl/config.json
+++ b/abx_plugins/plugins/forumdl/config.json
@@ -106,5 +106,7 @@
       ],
       "description": "Extra arguments to append to forum-dl command"
     }
-  }
+  },
+  "category": "text",
+  "display_order": 40
 }

--- a/abx_plugins/plugins/gallerydl/config.json
+++ b/abx_plugins/plugins/gallerydl/config.json
@@ -85,5 +85,7 @@
       ],
       "description": "Extra arguments to append to gallery-dl command"
     }
-  }
+  },
+  "category": "media",
+  "display_order": 50
 }

--- a/abx_plugins/plugins/git/config.json
+++ b/abx_plugins/plugins/git/config.json
@@ -73,5 +73,7 @@
       ],
       "description": "Extra arguments to append to git command"
     }
-  }
+  },
+  "category": "media",
+  "display_order": 60
 }

--- a/abx_plugins/plugins/hashes/config.json
+++ b/abx_plugins/plugins/hashes/config.json
@@ -26,5 +26,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for merkle tree generation in seconds"
     }
-  }
+  },
+  "category": "metadata",
+  "display_order": 100
 }

--- a/abx_plugins/plugins/headers/config.json
+++ b/abx_plugins/plugins/headers/config.json
@@ -28,5 +28,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for headers capture in seconds"
     }
-  }
+  },
+  "category": "metadata",
+  "display_order": 30
 }

--- a/abx_plugins/plugins/htmltotext/config.json
+++ b/abx_plugins/plugins/htmltotext/config.json
@@ -26,5 +26,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for HTML to text conversion in seconds"
     }
-  }
+  },
+  "category": "text",
+  "display_order": 20
 }

--- a/abx_plugins/plugins/infiniscroll/config.json
+++ b/abx_plugins/plugins/infiniscroll/config.json
@@ -55,5 +55,7 @@
       "default": true,
       "description": "Expand <details> elements and click 'load more' buttons for comments"
     }
-  }
+  },
+  "category": "page_setup",
+  "display_order": 20
 }

--- a/abx_plugins/plugins/istilldontcareaboutcookies/config.json
+++ b/abx_plugins/plugins/istilldontcareaboutcookies/config.json
@@ -32,5 +32,7 @@
       ],
       "description": "Enable I Still Don't Care About Cookies browser extension"
     }
-  }
+  },
+  "category": "page_setup",
+  "display_order": 50
 }

--- a/abx_plugins/plugins/liteparse/config.json
+++ b/abx_plugins/plugins/liteparse/config.json
@@ -192,5 +192,7 @@
       ],
       "description": "Extra arguments to append to LiteParse command"
     }
-  }
+  },
+  "category": "text",
+  "display_order": 70
 }

--- a/abx_plugins/plugins/media/config.json
+++ b/abx_plugins/plugins/media/config.json
@@ -7,5 +7,6 @@
   "required_plugins": [],
   "required_binaries": [],
   "output_mimetypes": [],
-  "properties": {}
+  "properties": {},
+  "hidden": true
 }

--- a/abx_plugins/plugins/mercury/config.json
+++ b/abx_plugins/plugins/mercury/config.json
@@ -74,5 +74,7 @@
       ],
       "description": "Extra arguments to append to Mercury parser command"
     }
-  }
+  },
+  "category": "text",
+  "display_order": 50
 }

--- a/abx_plugins/plugins/modalcloser/config.json
+++ b/abx_plugins/plugins/modalcloser/config.json
@@ -31,5 +31,7 @@
       "minimum": 100,
       "description": "How often to check for CSS modals (ms)"
     }
-  }
+  },
+  "category": "page_setup",
+  "display_order": 30
 }

--- a/abx_plugins/plugins/opencode/config.json
+++ b/abx_plugins/plugins/opencode/config.json
@@ -114,7 +114,6 @@
       "description": "Seconds to wait for OpenCode startup and proxied requests"
     }
   },
-  "x-runtimes": [
-    "archivebox"
-  ]
+  "x-auto-run": false,
+  "hidden": true
 }

--- a/abx_plugins/plugins/opendataloader/config.json
+++ b/abx_plugins/plugins/opendataloader/config.json
@@ -103,5 +103,7 @@
       ],
       "description": "Extra arguments to append to opendataloader-pdf command"
     }
-  }
+  },
+  "category": "text",
+  "display_order": 80
 }

--- a/abx_plugins/plugins/papersdl/config.json
+++ b/abx_plugins/plugins/papersdl/config.json
@@ -107,5 +107,7 @@
       ],
       "description": "Extra arguments to append to papers-dl command"
     }
-  }
+  },
+  "category": "text",
+  "display_order": 90
 }

--- a/abx_plugins/plugins/parse_dom_outlinks/config.json
+++ b/abx_plugins/plugins/parse_dom_outlinks/config.json
@@ -28,5 +28,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for DOM outlinks parsing in seconds"
     }
-  }
+  },
+  "category": "postprocessing",
+  "display_order": 10
 }

--- a/abx_plugins/plugins/parse_html_urls/config.json
+++ b/abx_plugins/plugins/parse_html_urls/config.json
@@ -19,5 +19,7 @@
       "description": "Enable HTML URL parsing"
     }
   },
-  "x-accepts-internal-input": true
+  "x-accepts-internal-input": true,
+  "category": "postprocessing",
+  "display_order": 20
 }

--- a/abx_plugins/plugins/parse_jsonl_urls/config.json
+++ b/abx_plugins/plugins/parse_jsonl_urls/config.json
@@ -19,5 +19,7 @@
       "description": "Enable JSON Lines URL parsing"
     }
   },
-  "x-accepts-internal-input": true
+  "x-accepts-internal-input": true,
+  "category": "postprocessing",
+  "display_order": 30
 }

--- a/abx_plugins/plugins/parse_netscape_urls/config.json
+++ b/abx_plugins/plugins/parse_netscape_urls/config.json
@@ -19,5 +19,7 @@
       "description": "Enable Netscape bookmarks HTML URL parsing"
     }
   },
-  "x-accepts-internal-input": true
+  "x-accepts-internal-input": true,
+  "category": "postprocessing",
+  "display_order": 40
 }

--- a/abx_plugins/plugins/parse_rss_urls/config.json
+++ b/abx_plugins/plugins/parse_rss_urls/config.json
@@ -35,5 +35,7 @@
       "description": "Enable RSS/Atom feed URL parsing"
     }
   },
-  "x-accepts-internal-input": true
+  "x-accepts-internal-input": true,
+  "category": "postprocessing",
+  "display_order": 50
 }

--- a/abx_plugins/plugins/parse_txt_urls/config.json
+++ b/abx_plugins/plugins/parse_txt_urls/config.json
@@ -19,5 +19,7 @@
       "description": "Enable plain text URL parsing"
     }
   },
-  "x-accepts-internal-input": true
+  "x-accepts-internal-input": true,
+  "category": "postprocessing",
+  "display_order": 60
 }

--- a/abx_plugins/plugins/pdf/config.json
+++ b/abx_plugins/plugins/pdf/config.json
@@ -35,5 +35,7 @@
       "x-fallback": "RESOLUTION",
       "description": "PDF page resolution (width,height)"
     }
-  }
+  },
+  "category": "main",
+  "display_order": 30
 }

--- a/abx_plugins/plugins/readability/config.json
+++ b/abx_plugins/plugins/readability/config.json
@@ -75,5 +75,7 @@
       ],
       "description": "Extra arguments to append to Readability command"
     }
-  }
+  },
+  "category": "text",
+  "display_order": 10
 }

--- a/abx_plugins/plugins/redirects/config.json
+++ b/abx_plugins/plugins/redirects/config.json
@@ -28,5 +28,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for redirect capture in seconds"
     }
-  }
+  },
+  "category": "metadata",
+  "display_order": 40
 }

--- a/abx_plugins/plugins/responses/config.json
+++ b/abx_plugins/plugins/responses/config.json
@@ -34,5 +34,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for response capture in seconds"
     }
-  }
+  },
+  "category": "media",
+  "display_order": 20
 }

--- a/abx_plugins/plugins/screenshot/config.json
+++ b/abx_plugins/plugins/screenshot/config.json
@@ -45,5 +45,7 @@
       "x-fallback": "RESOLUTION",
       "description": "Screenshot resolution (width,height)"
     }
-  }
+  },
+  "category": "main",
+  "display_order": 20
 }

--- a/abx_plugins/plugins/search_backend_ripgrep/config.json
+++ b/abx_plugins/plugins/search_backend_ripgrep/config.json
@@ -68,5 +68,6 @@
       ],
       "description": "Extra arguments to append to ripgrep command"
     }
-  }
+  },
+  "hidden": true
 }

--- a/abx_plugins/plugins/search_backend_sonic/config.json
+++ b/abx_plugins/plugins/search_backend_sonic/config.json
@@ -118,7 +118,6 @@
       "description": "Sonic bucket name"
     }
   },
-  "x-runtimes": [
-    "archivebox"
-  ]
+  "x-auto-run": false,
+  "hidden": true
 }

--- a/abx_plugins/plugins/search_backend_sonic/daemon.py
+++ b/abx_plugins/plugins/search_backend_sonic/daemon.py
@@ -122,7 +122,7 @@ def load_sonic_config(environ: Mapping[str, str] | None = None) -> Any:
             values[key] = prop.get("default") if isinstance(prop, Mapping) else ""
         else:
             values[key] = _coerce_env_value(raw_value, prop)
-    for key in ("ABX_RUNTIME", "CRAWL_DIR", "DATA_DIR", "EXTRA_CONTEXT", "SNAP_DIR"):
+    for key in ("CRAWL_DIR", "DATA_DIR", "EXTRA_CONTEXT", "SNAP_DIR"):
         values[key] = env.get(key, "")
     return SimpleNamespace(**values)
 

--- a/abx_plugins/plugins/search_backend_sonic/on_Snapshot__91_index_sonic.py
+++ b/abx_plugins/plugins/search_backend_sonic/on_Snapshot__91_index_sonic.py
@@ -243,11 +243,7 @@ def main() -> None:
     try:
         config = load_sonic_config()
 
-        if config.ABX_RUNTIME != "archivebox":
-            print("Skipping Sonic indexing (ABX_RUNTIME!=archivebox)", file=sys.stderr)
-            status = "skipped"
-            output_str = f"ABX_RUNTIME={config.ABX_RUNTIME}"
-        elif not is_sonic_backend_enabled(config):
+        if not is_sonic_backend_enabled(config):
             print(
                 "Skipping indexing (SEARCH_BACKEND_SONIC_ENABLED=False)",
                 file=sys.stderr,

--- a/abx_plugins/plugins/search_backend_sqlite/config.json
+++ b/abx_plugins/plugins/search_backend_sqlite/config.json
@@ -42,7 +42,6 @@
       "description": "FTS5 tokenizer configuration"
     }
   },
-  "x-runtimes": [
-    "archivebox"
-  ]
+  "x-auto-run": false,
+  "hidden": true
 }

--- a/abx_plugins/plugins/search_backend_sqlite/on_Snapshot__90_index_sqlite.py
+++ b/abx_plugins/plugins/search_backend_sqlite/on_Snapshot__90_index_sqlite.py
@@ -238,11 +238,7 @@ def main() -> None:
     text_size_kb = 0
 
     try:
-        if CONFIG.ABX_RUNTIME != "archivebox":
-            print("Skipping SQLite indexing (ABX_RUNTIME!=archivebox)", file=sys.stderr)
-            status = "skipped"
-            output_str = f"ABX_RUNTIME={CONFIG.ABX_RUNTIME}"
-        elif not CONFIG.SEARCH_BACKEND_SQLITE_ENABLED:
+        if not CONFIG.SEARCH_BACKEND_SQLITE_ENABLED:
             print(
                 "Skipping SQLite indexing (SEARCH_BACKEND_SQLITE_ENABLED=False)",
                 file=sys.stderr,

--- a/abx_plugins/plugins/search_backend_sqlite/search.py
+++ b/abx_plugins/plugins/search_backend_sqlite/search.py
@@ -53,11 +53,7 @@ def load_sqlite_config(environ: Mapping[str, str] | None = None) -> Any:
             values[key] = prop.get("default") if isinstance(prop, Mapping) else ""
         else:
             values[key] = _coerce_env_value(raw_value, prop)
-    values.update(
-        ABX_RUNTIME=env.get("ABX_RUNTIME", "abx-dl"),
-        DATA_DIR=env.get("DATA_DIR", ""),
-        SNAP_DIR=env.get("SNAP_DIR", ""),
-    )
+    values.update(DATA_DIR=env.get("DATA_DIR", ""), SNAP_DIR=env.get("SNAP_DIR", ""))
     return SimpleNamespace(**values)
 
 

--- a/abx_plugins/plugins/search_backend_sqlite/tests/test_sqlite_search.py
+++ b/abx_plugins/plugins/search_backend_sqlite/tests/test_sqlite_search.py
@@ -41,7 +41,6 @@ def test_load_sqlite_config_resolves_runtime_values_and_aliases(tmp_path: Path):
         },
     )
 
-    assert config.ABX_RUNTIME == "archivebox"
     assert config.DATA_DIR == str(tmp_path)
     assert config.SNAP_DIR == str(tmp_path / "snapshot")
     assert config.SEARCH_BACKEND_SQLITE_ENABLED is False

--- a/abx_plugins/plugins/seo/config.json
+++ b/abx_plugins/plugins/seo/config.json
@@ -28,5 +28,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for SEO capture in seconds"
     }
-  }
+  },
+  "category": "metadata",
+  "display_order": 90
 }

--- a/abx_plugins/plugins/singlefile/config.json
+++ b/abx_plugins/plugins/singlefile/config.json
@@ -42,5 +42,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for SingleFile in seconds"
     }
-  }
+  },
+  "category": "main",
+  "display_order": 40
 }

--- a/abx_plugins/plugins/ssl/config.json
+++ b/abx_plugins/plugins/ssl/config.json
@@ -7,5 +7,6 @@
   "required_plugins": [],
   "required_binaries": [],
   "output_mimetypes": [],
-  "properties": {}
+  "properties": {},
+  "hidden": true
 }

--- a/abx_plugins/plugins/sslcerts/config.json
+++ b/abx_plugins/plugins/sslcerts/config.json
@@ -28,5 +28,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for SSL capture in seconds"
     }
-  }
+  },
+  "category": "metadata",
+  "display_order": 70
 }

--- a/abx_plugins/plugins/staticfile/config.json
+++ b/abx_plugins/plugins/staticfile/config.json
@@ -39,5 +39,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for static file detection in seconds"
     }
-  }
+  },
+  "category": "media",
+  "display_order": 10
 }

--- a/abx_plugins/plugins/title/config.json
+++ b/abx_plugins/plugins/title/config.json
@@ -28,5 +28,7 @@
       "x-fallback": "TIMEOUT",
       "description": "Timeout for title extraction in seconds"
     }
-  }
+  },
+  "category": "metadata",
+  "display_order": 10
 }

--- a/abx_plugins/plugins/trafilatura/config.json
+++ b/abx_plugins/plugins/trafilatura/config.json
@@ -58,5 +58,7 @@
       "default": "txt,markdown,html",
       "description": "Comma-separated trafilatura output formats to write (txt, markdown, html, csv, json, xml, xmltei)"
     }
-  }
+  },
+  "category": "text",
+  "display_order": 60
 }

--- a/abx_plugins/plugins/twocaptcha/config.json
+++ b/abx_plugins/plugins/twocaptcha/config.json
@@ -79,5 +79,7 @@
       "default": false,
       "description": "Automatically submit forms after CAPTCHA is solved"
     }
-  }
+  },
+  "category": "page_setup",
+  "display_order": 60
 }

--- a/abx_plugins/plugins/ublock/config.json
+++ b/abx_plugins/plugins/ublock/config.json
@@ -32,5 +32,7 @@
       ],
       "description": "Enable uBlock Origin Lite browser extension for ad blocking"
     }
-  }
+  },
+  "category": "page_setup",
+  "display_order": 40
 }

--- a/abx_plugins/plugins/wget/config.json
+++ b/abx_plugins/plugins/wget/config.json
@@ -107,5 +107,7 @@
       ],
       "description": "Extra arguments to append to wget command"
     }
-  }
+  },
+  "category": "main",
+  "display_order": 50
 }

--- a/abx_plugins/plugins/ytdlp/config.json
+++ b/abx_plugins/plugins/ytdlp/config.json
@@ -156,5 +156,7 @@
       ],
       "description": "Extra arguments to append to yt-dlp command"
     }
-  }
+  },
+  "category": "media",
+  "display_order": 40
 }

--- a/tests/test_plugin_config_metadata.py
+++ b/tests/test_plugin_config_metadata.py
@@ -115,6 +115,36 @@ def test_every_plugin_has_config_json_with_required_metadata() -> None:
     )
 
 
+def test_plugin_presentation_metadata_is_generic_and_well_formed() -> None:
+    failures: list[str] = []
+    visible_orders: set[tuple[str, int]] = set()
+    for plugin_dir in _iter_plugin_dirs():
+        config = json.loads((plugin_dir / "config.json").read_text(encoding="utf-8"))
+        category = config.get("category", "")
+        display_order = config.get("display_order", 1000)
+        hidden = config.get("hidden", False)
+        auto_run = config.get("x-auto-run", True)
+        if not isinstance(category, str):
+            failures.append(f"{plugin_dir.name}: category must be a string")
+        if not isinstance(display_order, int) or isinstance(display_order, bool):
+            failures.append(f"{plugin_dir.name}: display_order must be an integer")
+        if not isinstance(hidden, bool):
+            failures.append(f"{plugin_dir.name}: hidden must be a boolean")
+        if not isinstance(auto_run, bool):
+            failures.append(f"{plugin_dir.name}: x-auto-run must be a boolean")
+        if not hidden and isinstance(category, str) and isinstance(display_order, int):
+            key = (category, display_order)
+            if key in visible_orders:
+                failures.append(
+                    f"{plugin_dir.name}: duplicate visible category/display_order {key!r}",
+                )
+            visible_orders.add(key)
+
+    assert not failures, (
+        "Plugin presentation metadata validation failed:\n" + "\n".join(failures)
+    )
+
+
 def test_required_binary_configs_follow_provider_policy() -> None:
     failures: list[str] = []
 


### PR DESCRIPTION
## Summary

- move plugin category, display order, and visibility into generic config.json metadata
- add x-auto-run for hooks that require explicit host selection
- remove ArchiveBox runtime branching from SQLite and Sonic search hooks
- keep every hook directly executable through filesystem, environment, and CLI inputs

## Boundary

Production plugin code imports neither ArchiveBox, abx-dl, nor Django. The plugin package remains independently executable and product-neutral.

## Validation

- prek run --all-files
- 40 metadata, dependency-boundary, SQLite, and Sonic tests passed
- broader suite reached 141 passed; 8 credential-gated Anthropic integration tests could not start because no API or OAuth credential was available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes plugin catalog metadata product-neutral by moving presentation fields into `config.json` and removing runtime-specific branching.

- Moves `category`, `display_order`, and `hidden` into each plugin's `config.json`.
- Adds `x-auto-run` (default true, set false on search backends and `opencode`) for hooks that require explicit host selection.
- Removes `ABX_RUNTIME` checks from SQLite and Sonic search hooks; they now run whenever enabled.
- Adds a test ensuring metadata is well-formed and visible category/order pairs are unique.

<sup>Written for commit b0d1e1d381c21a6b57df7c403c97a713fea1450d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

