### PR TITLE
refactor: simplify input and search hooks

### DIFF
--- a/abx_plugins/plugins/base/utils.js
+++ b/abx_plugins/plugins/base/utils.js
@@ -15,7 +15,6 @@ const path = require("path");
 
 const BASE_CONFIG_PATH = path.join(__dirname, "config.json");
 const PROCESS_EXIT_SKIPPED = 10;
-const INTERNAL_INPUT_URL = "archivebox://internal";
 const configCache = new Map();
 
 function writeFdFully(fd, text) {
@@ -186,11 +185,7 @@ function maybeSkipUnsupportedSnapshotUrl(schema) {
   const scriptName = path.basename(process.argv[1] || process.argv[0] || "");
   const url = argvUrl();
   if (!scriptName.startsWith("on_Snapshot__") || !url) return;
-  if (url.startsWith("http://") || url.startsWith("https://")) return;
-  // ArchiveBox uses one synthetic snapshot URL for pasted/stdin import text.
-  // Only plugins that explicitly opt in should consume that source; everything
-  // else should no-result before starting browsers/downloaders or networking.
-  if (url === INTERNAL_INPUT_URL && schema["x-accepts-internal-input"]) return;
+  if (url.startsWith("http://") || url.startsWith("https://") || url.startsWith("file://")) return;
   writeFdFully(
     1,
     `${JSON.stringify({
@@ -674,7 +669,6 @@ function iterStaticfileTextInputs(snapDir = null) {
 
 module.exports = {
   PROCESS_EXIT_SKIPPED,
-  INTERNAL_INPUT_URL,
   getConfig,
   loadConfig,
   getEnv,

--- a/abx_plugins/plugins/base/utils.py
+++ b/abx_plugins/plugins/base/utils.py
@@ -32,7 +32,6 @@ from typing import Any, TextIO, cast
 BASE_CONFIG_PATH = Path(__file__).with_name("config.json")
 PLUGINS_DIR = BASE_CONFIG_PATH.parent.parent
 PROCESS_EXIT_SKIPPED = 10
-INTERNAL_INPUT_URL = "archivebox://internal"
 
 
 def normalize_config_value(value: Any) -> Any:
@@ -152,13 +151,6 @@ def _maybe_skip_unsupported_snapshot_url(schema: Mapping[str, Any]) -> None:
         return
     if url.startswith(("http://", "https://", "file://")):
         return
-    # ArchiveBox represents pasted/stdin import content as one synthetic
-    # snapshot URL. Only plugins that explicitly declare they consume that
-    # internal input should run; every other snapshot hook should cheaply
-    # no-result before starting browsers/downloaders or touching the network.
-    if url == INTERNAL_INPUT_URL and bool(schema.get("x-accepts-internal-input")):
-        return
-
     record = {
         "type": "ArchiveResult",
         "status": "noresults",

--- a/abx_plugins/plugins/search_backend_sonic/on_Snapshot__91_index_sonic.py
+++ b/abx_plugins/plugins/search_backend_sonic/on_Snapshot__91_index_sonic.py
@@ -185,8 +185,6 @@ def index_in_sonic(snapshot_id: str, texts: list[str], config: Any) -> None:
     except ModuleNotFoundError:
         raise RuntimeError("sonic-client not installed. Run: pip install sonic-client")
     ingest_client: Any = sonic.IngestClient
-    control_client: Any = sonic.ControlClient
-
     with ingest_client(
         config.SEARCH_BACKEND_SONIC_HOST_NAME,
         config.SEARCH_BACKEND_SONIC_PORT,
@@ -213,13 +211,6 @@ def index_in_sonic(snapshot_id: str, texts: list[str], config: Any) -> None:
                 snapshot_id,
                 chunk,
             )
-
-    with control_client(
-        config.SEARCH_BACKEND_SONIC_HOST_NAME,
-        config.SEARCH_BACKEND_SONIC_PORT,
-        config.SEARCH_BACKEND_SONIC_PASSWORD,
-    ) as control:
-        control.trigger("consolidate")
 
 
 def get_snapshot_id_from_context() -> str:


### PR DESCRIPTION
## Summary

- remove the archivebox internal pseudo URL exception from shared URL validation
- allow real file URLs consistently in Python and JavaScript parser hooks
- remove per-snapshot Sonic consolidation now that indexing is orchestrated at snapshot scope

## Verification

- focused shared utility and Sonic tests: 4 passed
- all prek hooks passed, including Python type checks and JavaScript formatting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Snapshot input hooks now accept `file://` URLs in both Python and JavaScript, while removing the `archivebox://internal` exception so synthetic internal inputs are skipped like other unsupported URLs. Sonic indexing no longer consolidates after each snapshot; consolidation is left to snapshot-scope orchestration, avoiding an extra control connection per index.

**Verification**

- Focused utility and Sonic tests pass, along with all prek hooks, Python type checks, and JavaScript formatting.

<sup>Written for commit 58ea9fda2a2932ba7bd6e9096df221463c9468cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

