### PR TITLE
Document isolated OpenCode workdir default

### DIFF
--- a/abx_plugins/plugins/opencode/config.json
+++ b/abx_plugins/plugins/opencode/config.json
@@ -100,7 +100,7 @@
     "OPENCODE_WORKDIR": {
       "type": "string",
       "default": "",
-      "description": "Working directory for OpenCode. Defaults to the ArchiveBox data directory"
+      "description": "Working directory for OpenCode. Defaults to DATA_DIR/opencode/workdir so project scans do not walk archived snapshots"
     },
     "OPENCODE_STATE_DIR": {
       "type": "string",


### PR DESCRIPTION
OpenCode should use `DATA_DIR/opencode/workdir` as its project by default so opening the agent does not make VCS and file APIs scan archived snapshots.

This keeps the plugin config description aligned with the ArchiveBox runtime change.

Validation:
- `uv run pytest tests/test_plugin_config_metadata.py -q`
- `uv run prek run --files abx_plugins/plugins/opencode/config.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `OPENCODE_WORKDIR` config description to reflect the new isolated default of `DATA_DIR/opencode/workdir`, keeping project scans from walking archived snapshots.

<sup>Written for commit 795ec778f61d064fb926312ed08fb710c0f29b95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

