### PR TITLE
Allow cold OpenCode provider loading

### DIFF
--- a/abx_plugins/plugins/opencode/config.json
+++ b/abx_plugins/plugins/opencode/config.json
@@ -109,9 +109,9 @@
     },
     "OPENCODE_TIMEOUT": {
       "type": "integer",
-      "default": 30,
+      "default": 120,
       "minimum": 1,
-      "description": "Seconds to wait for OpenCode startup and proxied requests"
+      "description": "Seconds to wait for OpenCode startup and proxied requests, including cold provider catalog loading"
     }
   },
   "x-auto-run": false,


### PR DESCRIPTION
Raise the existing OpenCode startup/proxy timeout from 30s to 120s. OpenCode 1.17's cold provider catalog is about 5.7 MB and can take longer than 30s to generate, causing the embedded UI to receive transient 502 responses on first load.

This reuses the existing timeout setting; it adds no new config or compatibility path.

Verified with:
- `uv run pytest tests/test_plugin_config_metadata.py -q`
- `uv run prek run --files abx_plugins/plugins/opencode/config.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the OpenCode startup/proxy timeout default from 30s to 120s so cold provider catalog loading no longer causes transient 502 responses in the embedded UI.

<sup>Written for commit 4631533e271ad1cdf39fbfff59a3c92b70cc40d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

