### PR TITLE
Prefer prebuilt Sonic installer before package managers

### DIFF
--- a/abx_plugins/plugins/search_backend_sonic/config.json
+++ b/abx_plugins/plugins/search_backend_sonic/config.json
@@ -8,7 +8,7 @@
   "required_binaries": [
     {
       "name": "{SONIC_BINARY}",
-      "binproviders": "env,apt,brew,bash,cargo",
+      "binproviders": "env,bash,apt,brew,cargo",
       "min_version": null,
       "overrides": {
         "bash": {

--- a/abx_plugins/plugins/search_backend_sonic/tests/test_sonic_start.py
+++ b/abx_plugins/plugins/search_backend_sonic/tests/test_sonic_start.py
@@ -84,9 +84,9 @@ def test_sonic_required_binary_avoids_build_chain_on_linux_x86_64() -> None:
     apt_override = sonic_binary["overrides"]["apt"]
 
     assert config["properties"]["SEARCH_BACKEND_SONIC_ENABLED"]["default"] is True
-    assert provider_names == ["env", "apt", "brew", "bash", "cargo"]
-    assert provider_names.index("apt") < provider_names.index("bash")
-    assert provider_names.index("apt") < provider_names.index("cargo")
+    assert provider_names == ["env", "bash", "apt", "brew", "cargo"]
+    assert provider_names.index("bash") < provider_names.index("apt")
+    assert provider_names.index("bash") < provider_names.index("cargo")
     assert bash_override["install_args"] == ["sonic@1.7.4"]
     assert (
         "81b1d017992ffc9957dc27f7f6c78fd2cf1a4e09c89295dc8b15d15ded01b8ae"


### PR DESCRIPTION
## Summary

- prefer the pinned SHA-verified Sonic Linux x86_64 prebuilt immediately after environment discovery
- retain apt, brew, and cargo as fallback providers
- update the provider-order regression assertion

## Why

The ArchiveBox CI workflow timed out after 60 seconds inside `archivebox install search_backend_sonic` while the Packagecloud apt endpoint was returning HTTP 429. The pinned GitHub prebuilt remained fast and deterministic, but was attempted only after apt and brew. This keeps the same fallback behavior while avoiding package-manager/repository setup on the supported Linux x86_64 fast path.

## Verification

- `uv run pytest abx_plugins/plugins/search_backend_sonic/tests/test_sonic_start.py -q` (3 passed)
- real Linux x86_64 Docker install with global Sonic masked and a fresh `ABXPKG_LIB_DIR`: resolved via `bash` in 6 seconds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorders Sonic's binary providers so the pinned SHA-verified prebuilt installer (via `bash`) is tried before `apt`, `brew`, and `cargo`. Previously `apt` was tried first, which caused CI timeouts when the Packagecloud endpoint returned HTTP 429; the prebuilt path stays fast and deterministic, and the package managers remain as fallbacks.

- Updates the provider-order regression assertion in `test_sonic_start.py`.

<sup>Written for commit 6c202b0f35d0786b8c7c58853c7b36a7b60c4e4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

