### PR TITLE
Accept projected required binary paths

### DIFF
--- a/abx_plugins/plugins/base/utils.py
+++ b/abx_plugins/plugins/base/utils.py
@@ -837,6 +837,10 @@ def _find_hydrated_required_binary(
     hydrated_records = [
         (record, hydrate_required_binary(record, payload)) for record in records
     ]
+    requested_path = Path(name).expanduser()
+    requested_is_path = requested_path.is_absolute() or requested_path.parent != Path(
+        ".",
+    )
 
     # Prefer the effective runtime name so callers can select an explicitly
     # configured path without it being mistaken for another declaration.
@@ -845,17 +849,25 @@ def _find_hydrated_required_binary(
             return hydrated_record
 
     # A required binary whose name comes from a config property still has a
-    # stable declaration identity: that property's schema default.  Environment
-    # hydration may replace the runtime name with an absolute path, but callers
-    # must continue to be able to select the declaration by its configured
-    # command name (for example ``lit`` or ``wget``).
+    # stable declaration identity: that property's schema default. A projected
+    # managed path has the same identity as its basename even if stale process
+    # environment hydration still contains the original command name.
     for record, hydrated_record in hydrated_records:
         key = _placeholder_config_key(record.get("name"))
         property_schema = properties.get(key) if key is not None else None
-        if (
-            isinstance(property_schema, Mapping)
-            and property_schema.get("default") == name
-        ):
+        default_name = (
+            property_schema.get("default")
+            if isinstance(property_schema, Mapping)
+            else None
+        )
+        matches_projected_path = (
+            requested_is_path
+            and isinstance(default_name, str)
+            and Path(default_name).name == requested_path.name
+        )
+        if default_name == name or matches_projected_path:
+            if matches_projected_path:
+                hydrated_record["name"] = name
             return hydrated_record
 
     raise KeyError(f"{resolved_path} required_binaries is missing {name!r}")

--- a/abx_plugins/plugins/search_backend_sonic/tests/test_sonic_start.py
+++ b/abx_plugins/plugins/search_backend_sonic/tests/test_sonic_start.py
@@ -114,3 +114,17 @@ def test_sonic_required_binary_avoids_build_chain_on_linux_x86_64() -> None:
         "--version",
         "1.4.9",
     ]
+
+
+def test_sonic_required_binary_accepts_projected_managed_path(tmp_path: Path) -> None:
+    from abx_plugins.plugins.base.utils import get_hydrated_required_binary
+
+    projected_binary = tmp_path / "lib" / "bash" / "bin" / "sonic"
+    record = get_hydrated_required_binary(
+        str(projected_binary),
+        PLUGIN_DIR / "config.json",
+        global_config={"SONIC_BINARY": str(projected_binary)},
+        environ={"SONIC_BINARY": "sonic"},
+    )
+
+    assert record["name"] == str(projected_binary)


### PR DESCRIPTION
## Summary

- recognize an absolute managed binary path by the basename of its placeholder-backed schema declaration
- preserve the requested absolute path when loading that binary
- cover the ArchiveBox Sonic daemon case where resolved config and process-environment hydration differ

## Why

The full ArchiveBox search E2E exposed the issue after Sonic began using the managed prebuilt path: `SONIC_BINARY` was projected to `.../lib/bash/bin/sonic`, but the generic config loader could only identify the declaration by an exact hydrated name or the raw schema default (`sonic`). It raised `required_binaries is missing` before starting the daemon.

## Verification

- `uv run pytest abx_plugins/plugins/search_backend_sonic/tests/test_sonic_start.py -q` (4 passed)
- `uv run pytest tests/test_plugin_config_metadata.py -q` (7 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the required-binary config loader so projected managed paths like `.../lib/bash/bin/sonic` resolve to their schema declaration instead of raising `required_binaries is missing`.

- Matches projected absolute paths to the declaration by basename and preserves the requested path.
- Covers the ArchiveBox Sonic daemon case where config projection and stale process environment hydration differ.

<sup>Written for commit 1f56f29aff2cd3b522828c4fa932c4bdf644f097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

