### PR TITLE
Move optional OpenCode runtime and UI into its plugin

### DIFF
--- a/abx_plugins/plugins/opencode/README.md
+++ b/abx_plugins/plugins/opencode/README.md
@@ -1,0 +1,19 @@
+# OpenCode
+
+This optional plugin owns the OpenCode process, dependency resolution, isolated
+state, session setup, HTTP/SSE forwarding, and agent UI templates. Importing the
+plugin package does not import or start its runtime. The runtime's HTTP clients
+are declared in the `opencode` package extra.
+
+ArchiveBox supplies a thin, lazy Django adapter: authentication, collection and
+route context, template rendering, and conversion to Django responses. The
+runtime imports neither ArchiveBox nor Django. A failed import, startup, request,
+or template returns an AI-only unavailable response; failed streams report an
+error event and close. Ordinary pages do not import the runtime.
+
+OpenCode works directly in the collection directory without initializing Git.
+Checkpointing defaults to disabled. State and credentials stay under
+`DATA_DIR/opencode`; existing user configuration is preserved.
+
+Runtime tests live in `tests/test_runtime.py`. The host's authentication,
+HTTP/streaming, and incomplete-install integration tests live in ArchiveBox.

--- a/abx_plugins/plugins/opencode/README.md
+++ b/abx_plugins/plugins/opencode/README.md
@@ -11,6 +11,9 @@ runtime imports neither ArchiveBox nor Django. A failed import, startup, request
 or template returns an AI-only unavailable response; failed streams report an
 error event and close. Ordinary pages do not import the runtime.
 
+The wrapper preserves existing browser-side servers and projects. Unavailable
+or full browser storage cannot suppress the access warning or block dismissal.
+
 OpenCode works directly in the collection directory without initializing Git.
 Checkpointing defaults to disabled. State and credentials stay under
 `DATA_DIR/opencode`; existing user configuration is preserved.

--- a/abx_plugins/plugins/opencode/config.json
+++ b/abx_plugins/plugins/opencode/config.json
@@ -73,7 +73,7 @@
     "GIT_BINARY": {
       "type": "string",
       "default": "git",
-      "description": "Path to Git binary used by OpenCode project initialization"
+      "description": "Path to Git binary used by OpenCode to inspect existing projects; ArchiveBox never initializes a repository"
     },
     "OPENCODE_ENABLED": {
       "type": "boolean",
@@ -100,7 +100,7 @@
     "OPENCODE_WORKDIR": {
       "type": "string",
       "default": "",
-      "description": "Working directory for OpenCode. Defaults to DATA_DIR/opencode/workdir so project scans do not walk archived snapshots"
+      "description": "Working directory for OpenCode. Defaults to DATA_DIR; no Git repository is created and checkpointing is disabled by default"
     },
     "OPENCODE_STATE_DIR": {
       "type": "string",

--- a/abx_plugins/plugins/opencode/runtime.py
+++ b/abx_plugins/plugins/opencode/runtime.py
@@ -117,6 +117,7 @@ def _config_value(config: dict, key: str, default):
 
 
 def _origin_allowed(method: str, expected_host: str, headers) -> bool:
+    """Called by the host's authenticated adapter before invoking proxy()."""
     if method in {"GET", "HEAD", "OPTIONS", "TRACE"}:
         return True
 
@@ -531,6 +532,7 @@ async def _event_chunks(settings, path, method, params, headers):
 
 
 def proxy(settings: dict, method: str, path: str, params, headers, body: bytes):
+    """Forward a request after the host authenticates it and checks its origin."""
     forwarded = {
         key: headers[key]
         for key in ("Accept", "Accept-Language", "Content-Type", "Range", "User-Agent")

--- a/abx_plugins/plugins/opencode/runtime.py
+++ b/abx_plugins/plugins/opencode/runtime.py
@@ -1,0 +1,572 @@
+from __future__ import annotations
+
+import asyncio
+import atexit
+import base64
+import logging
+import os
+import re
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+import httpx
+import requests
+
+_PROCESS: subprocess.Popen | None = None
+_PROCESS_READY: subprocess.Popen | None = None
+_PROCESS_LOCK = threading.Lock()
+_SESSION_LOCK = threading.Lock()
+_LOGGER = logging.getLogger(__name__)
+_PROXY_PREFIX = "/admin/agent/opencode"
+_PROXY_PREFIX_REGEX = _PROXY_PREFIX.replace("/", r"\/")
+_PROXY_PREFIX_NO_SLASH_REGEX = _PROXY_PREFIX.lstrip("/").replace("/", r"\/")
+_CONFIG_PATH = Path(__file__).with_name("config.json")
+_DEFAULT_MODEL = "opencode/big-pickle"
+_DEFAULT_CONFIG = f'''{{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "{_DEFAULT_MODEL}",
+  "snapshot": false
+}}
+'''
+
+_TEXT_CONTENT_TYPES = (
+    "text/",
+    "application/javascript",
+    "application/x-javascript",
+)
+_HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+_ARCHIVEBOX_SKILL = """---
+name: archivebox
+description: Use ArchiveBox's CLI and local REST API from an ArchiveBox collection.
+---
+
+You are running inside an ArchiveBox collection directory.
+
+- ArchiveBox collection directory: {archivebox_data_dir}
+- ArchiveBox BASE_URL: {archivebox_base_url}
+- ArchiveBox Admin URL: {archivebox_admin_url}
+- ArchiveBox REST API URL: {archivebox_api_url}
+- Prefer the `archivebox` CLI for authenticated changes, e.g. `archivebox add`, `archivebox schedule`, `archivebox update`, and `archivebox shell`.
+- Run ArchiveBox CLI commands from the ArchiveBox collection directory above.
+- Get command help with `archivebox list --help`, `archivebox add --help`, `archivebox schedule --help`, etc. Do not use `archivebox help <command>`.
+- Use `--depth=0` by default. Only use recursive crawling when the user explicitly asks for it; use `--depth=1` when you need pages one hop out.
+- Before any recursive crawl, constrain scope with ArchiveBox config such as `CRAWL_MAX_URLS`, `CRAWL_MAX_SIZE`, `SNAPSHOT_MAX_*`, `URL_ALLOWLIST`, `URL_DENYLIST`, and related limits.
+- Respect the configured `archivebox config --get ONLY_NEW` behavior unless the user explicitly says otherwise. Remind users that expected crawl URLs can be skipped when the collection already contains snapshots with the same URL.
+- Always audit newly discovered crawl URLs before letting a crawl run broadly. Treat junk URLs such as privacy policies, legal pages, tag archives, sitemap files, feeds, login/logout URLs, and other low-value boilerplate as unwanted unless the user explicitly asked to archive them.
+- Always watch crawl output and logs as the crawl progresses, and correct errors early instead of waiting until the crawl finishes.
+- If a crawl contains bad URLs, pause it, edit the crawl's `urls` field to remove them, delete any unneeded snapshots already created under that crawl, then resume the crawl.
+- Use `archivebox shell -c '...'` or `archivebox shell <<'PY' ... PY` for Django ORM work. Shell Plus prints an import banner first; keep stderr visible while debugging.
+- Use full ArchiveBox module paths in shell code: `from archivebox.crawls.models import Crawl, CrawlSchedule` and `from archivebox.core.models import Snapshot, ArchiveResult`.
+- If a model/field/relation is unclear, inspect `_meta.fields` before guessing, e.g. `archivebox shell -c "from archivebox.crawls.models import Crawl; print([f.name for f in Crawl._meta.fields])"`.
+- Use `archivebox config --get BASE_URL` only to verify the configured base URL; prefer the seeded URLs above for API/admin requests.
+- Use `$ARCHIVEBOX_API_URL` for REST API inspection when helpful. Do not assume admin session cookies authenticate API subdomain requests; prefer CLI/shell for authenticated mutations unless the admin provides or asks you to create an API token.
+- Discover REST endpoints from `${{ARCHIVEBOX_API_URL}}v1/openapi.json`; crawl endpoints live under `/api/v1/crawls/`, snapshots under `/api/v1/core/`.
+- Do not bypass ArchiveBox auth, expose API keys, or modify config unless the admin explicitly asks.
+- After creating crawls or snapshots, report the crawl/snapshot IDs and the exact command or API request used.
+"""
+
+
+def _signal_owned_process(process: subprocess.Popen, sig: signal.Signals) -> None:
+    try:
+        os.killpg(process.pid, sig)
+    except OSError:
+        try:
+            process.send_signal(sig)
+        except ProcessLookupError:
+            pass
+
+
+def _stop_owned_process(process: subprocess.Popen | None = None) -> None:
+    global _PROCESS, _PROCESS_READY
+    owned_process = process or _PROCESS
+    if owned_process is None:
+        return
+    if owned_process.poll() is None:
+        _signal_owned_process(owned_process, signal.SIGCONT)
+        _signal_owned_process(owned_process, signal.SIGTERM)
+        try:
+            owned_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            _signal_owned_process(owned_process, signal.SIGKILL)
+            owned_process.wait()
+    if _PROCESS is owned_process:
+        _PROCESS = None
+    if _PROCESS_READY is owned_process:
+        _PROCESS_READY = None
+
+
+def _config_value(config: dict, key: str, default):
+    value = config.get(key, default)
+    if value in (None, ""):
+        return default
+    return value
+
+
+def _origin_allowed(method: str, expected_host: str, headers) -> bool:
+    if method in {"GET", "HEAD", "OPTIONS", "TRACE"}:
+        return True
+
+    origin = headers.get("Origin")
+    if origin:
+        return _same_host(origin, expected_host)
+
+    referer = headers.get("Referer")
+    if referer:
+        return _same_host(referer, expected_host)
+
+    fetch_site = headers.get("Sec-Fetch-Site")
+    if fetch_site:
+        return fetch_site in {"same-origin", "same-site", "none"}
+
+    return False
+
+
+def _same_host(value: str, expected_host: str) -> bool:
+    parsed = urlsplit(value)
+    return parsed.scheme in {"http", "https"} and parsed.netloc == expected_host
+
+
+def _settings(config: dict, data_dir: Path | None = None) -> dict:
+    host = str(_config_value(config, "OPENCODE_HOST", "127.0.0.1"))
+    port = int(_config_value(config, "OPENCODE_PORT", 4096))
+    default_data_dir = Path(
+        data_dir or config.get("DATA_DIR") or os.environ.get("DATA_DIR") or ".",
+    ).resolve()
+    opencode_dir = Path(
+        str(_config_value(config, "OPENCODE_STATE_DIR", default_data_dir / "opencode")),
+    ).expanduser()
+    workdir = Path(
+        str(_config_value(config, "OPENCODE_WORKDIR", default_data_dir)),
+    ).expanduser()
+    binary = str(_config_value(config, "OPENCODE_BINARY", "opencode"))
+    timeout = int(_config_value(config, "OPENCODE_TIMEOUT", 120))
+    return {
+        "host": host,
+        "port": port,
+        "origin": f"http://{host}:{port}",
+        "archivebox_data_dir": default_data_dir,
+        "workdir": workdir,
+        "opencode_dir": opencode_dir,
+        "config_home": opencode_dir / "config",
+        "data_home": opencode_dir / "data",
+        "state_home": opencode_dir / "state",
+        "cache_home": opencode_dir / "cache",
+        "home": opencode_dir / "home",
+        "binary": binary,
+        "config": config,
+        "timeout": timeout,
+    }
+
+
+def _resolve_binary(binary: str, config: dict) -> tuple[Any, dict[str, str]]:
+    try:
+        from abxpkg import BinProvider
+        from abx_plugins.plugins.base.utils import load_required_binary_from_config
+
+        binary_environ = os.environ.copy()
+        lib_dir = config.get("ABXPKG_LIB_DIR")
+        if lib_dir:
+            binary_environ["ABXPKG_LIB_DIR"] = str(lib_dir)
+        loaded_dependencies = [
+            load_required_binary_from_config(
+                required_binary,
+                _CONFIG_PATH,
+                global_config=config,
+                environ=binary_environ,
+                install=False,
+            )
+            for required_binary in (
+                str(config.get("NODE_BINARY") or "node"),
+                str(config.get("GIT_BINARY") or "git"),
+                binary,
+            )
+        ]
+    except Exception as err:
+        raise RuntimeError(
+            f"OpenCode dependency is not installed from required_binaries: {err}",
+        ) from err
+
+    if any(not loaded.loaded_abspath for loaded in loaded_dependencies):
+        raise RuntimeError(
+            "OpenCode dependency is not installed from required_binaries.",
+        )
+
+    providers = [
+        loaded.loaded_binprovider
+        for loaded in loaded_dependencies
+        if loaded.loaded_binprovider is not None
+    ]
+    binary_env = BinProvider.build_exec_env(
+        providers=providers,
+        base_env=binary_environ,
+    )
+    return loaded_dependencies[-1], binary_env
+
+
+def _project_route(workdir: Path, session_id: str = "") -> str:
+    encoded = base64.b64encode(str(workdir.resolve()).encode()).decode()
+    encoded = encoded.replace("+", "-").replace("/", "_").rstrip("=")
+    route = f"{_PROXY_PREFIX}/{encoded}/session"
+    return f"{route}/{session_id}" if session_id else route
+
+
+def _ensure_project_files(settings: dict) -> None:
+    workdir = settings["workdir"].resolve()
+    workdir.mkdir(parents=True, exist_ok=True)
+    editable_skill_path = settings["opencode_dir"] / "SKILL.md"
+    editable_skill_path.parent.mkdir(parents=True, exist_ok=True)
+    if not editable_skill_path.exists():
+        editable_skill_path.write_text(
+            _ARCHIVEBOX_SKILL.format(
+                archivebox_data_dir=settings["archivebox_data_dir"],
+                archivebox_base_url=settings.get("archivebox_base_url", ""),
+                archivebox_admin_url=settings.get("archivebox_admin_url", ""),
+                archivebox_api_url=settings.get("archivebox_api_url", ""),
+            ),
+        )
+
+    opencode_skill_path = (
+        settings["config_home"] / "opencode" / "skills" / "archivebox" / "SKILL.md"
+    )
+    opencode_skill_path.parent.mkdir(parents=True, exist_ok=True)
+    if opencode_skill_path.resolve() != editable_skill_path.resolve():
+        if opencode_skill_path.exists() or opencode_skill_path.is_symlink():
+            opencode_skill_path.unlink()
+        opencode_skill_path.symlink_to(editable_skill_path)
+
+    opencode_config_path = settings["config_home"] / "opencode" / "opencode.jsonc"
+    if not opencode_config_path.exists():
+        opencode_config_path.write_text(_DEFAULT_CONFIG)
+
+
+def _ensure_default_session(settings: dict) -> str:
+    workdir = settings["workdir"].resolve()
+    params = {"directory": str(workdir)}
+    timeout = settings["timeout"]
+    sessions = requests.get(
+        f"{settings['origin']}/session",
+        params={**params, "roots": "true", "limit": 55},
+        timeout=timeout,
+    )
+    sessions.raise_for_status()
+    session_data = sessions.json()
+    if not isinstance(session_data, list):
+        raise RuntimeError("OpenCode returned an invalid project session list.")
+    for session_data_item in session_data:
+        if not isinstance(session_data_item, dict):
+            continue
+        session_id = str(session_data_item.get("id") or "")
+        session_directory = session_data_item.get("directory")
+        if (
+            session_id
+            and session_directory
+            and Path(str(session_directory)).resolve() == workdir
+        ):
+            return session_id
+
+    session = requests.post(
+        f"{settings['origin']}/session",
+        params=params,
+        json={},
+        timeout=timeout,
+    )
+    session.raise_for_status()
+    session_data = session.json()
+    session_id = str(session_data.get("id") or "")
+    session_directory = session_data.get("directory")
+    if (
+        not session_id
+        or not session_directory
+        or Path(str(session_directory)).resolve() != workdir
+    ):
+        raise RuntimeError(
+            "OpenCode did not create a session for the requested worktree.",
+        )
+    return session_id
+
+
+def _owned_process_running() -> bool:
+    process = _PROCESS
+    return process is not None and process.poll() is None
+
+
+def _owned_process_ready() -> bool:
+    process = _PROCESS_READY
+    return process is not None and process is _PROCESS and process.poll() is None
+
+
+def _health(settings: dict, timeout: float = 2) -> bool:
+    try:
+        response = requests.get(
+            f"{settings['origin']}/global/health",
+            timeout=timeout,
+        )
+        return response.status_code == 200
+    except requests.RequestException:
+        return False
+
+
+def _ensure_opencode(settings: dict) -> tuple[bool, str]:
+    global _PROCESS, _PROCESS_READY
+    started_process: subprocess.Popen | None = None
+    workdir = settings["workdir"].resolve()
+
+    with _PROCESS_LOCK:
+        if _owned_process_ready():
+            return True, ""
+        if _health(settings):
+            if _owned_process_running():
+                _PROCESS_READY = _PROCESS
+            return True, ""
+        if _owned_process_running():
+            _stop_owned_process(_PROCESS)
+
+        try:
+            binary, binary_env = _resolve_binary(
+                settings["binary"],
+                settings["config"],
+            )
+        except RuntimeError as err:
+            return False, str(err)
+
+        env = {
+            **os.environ,
+            **binary_env,
+            "ARCHIVEBOX_BASE_URL": str(settings.get("archivebox_base_url", "")),
+            "ARCHIVEBOX_ADMIN_URL": str(settings.get("archivebox_admin_url", "")),
+            "ARCHIVEBOX_API_URL": str(settings.get("archivebox_api_url", "")),
+            "BROWSER": "false",
+            "GIT_CEILING_DIRECTORIES": str(workdir),
+            "HOME": str(settings["home"]),
+            "OPENCODE_DISABLE_PROJECT_CONFIG": "true",
+            "XDG_CONFIG_HOME": str(settings["config_home"]),
+            "XDG_DATA_HOME": str(settings["data_home"]),
+            "XDG_STATE_HOME": str(settings["state_home"]),
+            "XDG_CACHE_HOME": str(settings["cache_home"]),
+        }
+
+        settings["workdir"].mkdir(parents=True, exist_ok=True)
+        settings["config_home"].mkdir(parents=True, exist_ok=True)
+        settings["data_home"].mkdir(parents=True, exist_ok=True)
+        settings["state_home"].mkdir(parents=True, exist_ok=True)
+        settings["cache_home"].mkdir(parents=True, exist_ok=True)
+        settings["home"].mkdir(parents=True, exist_ok=True)
+        _ensure_project_files(settings)
+
+        if _health(settings):
+            return True, ""
+
+        binary_abspath = binary.loaded_abspath
+        if binary.loaded_binprovider is not None:
+            binary_abspath = binary.loaded_binprovider._exec_bin_abspath(
+                Path(binary.loaded_abspath),
+            )
+        cmd = [
+            str(binary_abspath),
+            "serve",
+            "--hostname",
+            settings["host"],
+            "--port",
+            str(settings["port"]),
+        ]
+        try:
+            _PROCESS = subprocess.Popen(
+                cmd,
+                cwd=workdir,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            _PROCESS_READY = None
+            started_process = _PROCESS
+        except FileNotFoundError:
+            return False, f"OpenCode binary not found: {settings['binary']}"
+
+        deadline = time.monotonic() + settings["timeout"]
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            if _health(settings, timeout=min(2, remaining)):
+                if time.monotonic() <= deadline:
+                    _PROCESS_READY = started_process
+                    return True, ""
+                break
+            if started_process and started_process.poll() is not None:
+                if _PROCESS is started_process:
+                    _PROCESS = None
+                if _PROCESS_READY is started_process:
+                    _PROCESS_READY = None
+                return False, "OpenCode exited before the web server became ready."
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                time.sleep(min(0.25, remaining))
+
+        _stop_owned_process(started_process)
+        return False, "Timed out waiting for OpenCode to start."
+
+
+def _proxy_url(settings: dict, path: str | None) -> str:
+    rel = "/" if not path else f"/{path}"
+    return urljoin(settings["origin"], rel)
+
+
+def _rewrite_text(body: bytes, settings: dict) -> bytes:
+    text = body.decode("utf-8", errors="replace")
+    text = text.replace(settings["origin"], _PROXY_PREFIX)
+    text = text.replace("location.origin", f'location.origin+"{_PROXY_PREFIX}"')
+    text = text.replace(
+        "k(k5,{get component(){return t.router??Az},",
+        f'k(k5,{{base:"{_PROXY_PREFIX}",get component(){{return t.router??Az}},',
+    )
+    text = text.replace('"/assets/', f'"{_PROXY_PREFIX}/assets/')
+    text = text.replace("'/assets/", f"'{_PROXY_PREFIX}/assets/")
+    proxy_path = rf'(\1.replace(/^{_PROXY_PREFIX_REGEX}(?=\/|$)/,"")||"/")'
+    text = re.sub(r"\b(window\.location\.pathname)\b", proxy_path, text)
+    text = re.sub(r"(?<![.\w])(location\.pathname)\b", proxy_path, text)
+    text = text.replace(
+        'window.history.replaceState(nz(o),"",r):window.history.pushState(o,"",r)',
+        (
+            f'window.history.replaceState(nz(o),"",r.startsWith("{_PROXY_PREFIX}")?r:r.startsWith("/")?"{_PROXY_PREFIX}"+r:r):'
+            f'window.history.pushState(o,"",r.startsWith("{_PROXY_PREFIX}")?r:r.startsWith("/")?"{_PROXY_PREFIX}"+r:r)'
+        ),
+    )
+    text = text.replace(
+        'const BL="modulepreload",UL=function(t){return"/"+t}',
+        f'const BL="modulepreload",UL=function(t){{return"{_PROXY_PREFIX}/"+t}}',
+    )
+    text = re.sub(
+        rf"""(?P<prefix>\b(?:href|src|action)=["'])/(?!{_PROXY_PREFIX_NO_SLASH_REGEX}(?:/|$))""",
+        rf"\g<prefix>{_PROXY_PREFIX}/",
+        text,
+    )
+    text = re.sub(
+        rf"""(?P<prefix>\b(?:fetch|EventSource)\(["'])/(?!{_PROXY_PREFIX_NO_SLASH_REGEX}(?:/|$))""",
+        rf"\g<prefix>{_PROXY_PREFIX}/",
+        text,
+    )
+    text = re.sub(
+        rf"""(?P<prefix>\burl\(["']?)/(?!{_PROXY_PREFIX_NO_SLASH_REGEX}(?:/|$))""",
+        rf"\g<prefix>{_PROXY_PREFIX}/",
+        text,
+    )
+    return text.encode("utf-8")
+
+
+def _response_headers(upstream: requests.Response, settings: dict) -> dict[str, str]:
+    headers = {}
+    for key, value in upstream.headers.items():
+        lower = key.lower()
+        if lower in _HOP_BY_HOP_HEADERS or lower in {
+            "content-length",
+            "content-encoding",
+            "x-frame-options",
+        }:
+            continue
+        if lower == "location":
+            if value.startswith(settings["origin"]):
+                value = value.replace(settings["origin"], _PROXY_PREFIX, 1)
+            elif value.startswith("/"):
+                value = f"{_PROXY_PREFIX}{value}"
+        headers[key] = value
+    return headers
+
+
+atexit.register(_stop_owned_process)
+
+
+def agent_context(settings: dict) -> dict:
+    ok, error = _ensure_opencode(settings)
+    if not ok:
+        raise RuntimeError(error)
+    with _SESSION_LOCK:
+        session_id = _ensure_default_session(settings)
+    return {
+        "title": "Agent",
+        "proxy_url": _project_route(settings["workdir"], session_id),
+        "proxy_prefix": _PROXY_PREFIX,
+        "workdir": str(settings["workdir"].resolve()),
+        "recent_session_id": session_id,
+    }
+
+
+async def _event_chunks(settings, path, method, params, headers):
+    # Stream failures happen after the host returns response headers.
+    try:
+        if not _owned_process_ready():
+            ok, error = await asyncio.to_thread(_ensure_opencode, settings)
+            if not ok:
+                raise RuntimeError(error)
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(settings["timeout"], read=None),
+            follow_redirects=False,
+        ) as client:
+            async with client.stream(
+                method,
+                _proxy_url(settings, path),
+                params=params,
+                headers=headers,
+            ) as upstream:
+                upstream.raise_for_status()
+                async for chunk in upstream.aiter_raw(chunk_size=512):
+                    yield chunk
+    except Exception:
+        _LOGGER.exception("OpenCode event stream failed")
+        yield b'event: error\ndata: {"error":"OpenCode unavailable"}\n\n'
+
+
+def proxy(settings: dict, method: str, path: str, params, headers, body: bytes):
+    forwarded = {
+        key: headers[key]
+        for key in ("Accept", "Accept-Language", "Content-Type", "Range", "User-Agent")
+        if headers.get(key)
+    }
+    if method == "GET" and path.endswith("/event"):
+        return (
+            200,
+            {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-store",
+                "X-Accel-Buffering": "no",
+            },
+            _event_chunks(settings, path, method, params, forwarded),
+        )
+
+    if path == "global/health" or not _owned_process_ready():
+        ok, error = _ensure_opencode(settings)
+        if not ok:
+            raise RuntimeError(error)
+
+    with requests.request(
+        method,
+        _proxy_url(settings, path),
+        params=params,
+        data=body if method not in {"GET", "HEAD"} else None,
+        headers=forwarded,
+        timeout=settings["timeout"],
+        allow_redirects=False,
+    ) as upstream:
+        content = upstream.content
+        response_headers = _response_headers(upstream, settings)
+        if any(
+            upstream.headers.get("Content-Type", "").startswith(prefix)
+            for prefix in _TEXT_CONTENT_TYPES
+        ):
+            content = _rewrite_text(content, settings)
+        response_headers["Cache-Control"] = "no-store"
+        return upstream.status_code, response_headers, content

--- a/abx_plugins/plugins/opencode/templates/add.html
+++ b/abx_plugins/plugins/opencode/templates/add.html
@@ -1,3 +1,3 @@
 {% if user.is_authenticated and user.is_superuser and request.archivebox_config.OPENCODE_ENABLED %}
-    <a href="/admin/agent">💬 Crawl with AI</a> &nbsp; | &nbsp;
+    <a href="{% url 'opencode-agent' %}">💬 Crawl with AI</a> &nbsp; | &nbsp;
 {% endif %}

--- a/abx_plugins/plugins/opencode/templates/add.html
+++ b/abx_plugins/plugins/opencode/templates/add.html
@@ -1,0 +1,3 @@
+{% if user.is_authenticated and user.is_superuser and request.archivebox_config.OPENCODE_ENABLED %}
+    <a href="/admin/agent">💬 Crawl with AI</a> &nbsp; | &nbsp;
+{% endif %}

--- a/abx_plugins/plugins/opencode/templates/agent.html
+++ b/abx_plugins/plugins/opencode/templates/agent.html
@@ -1,0 +1,211 @@
+{% extends "admin/base.html" %}
+{% load i18n %}
+
+{% block title %}Agent{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+        &rsaquo; Agent
+    </div>
+{% endblock %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <style>
+        body.opencode-agent #content {
+            padding: 0;
+        }
+        body.opencode-agent #content-main {
+            height: calc(100vh - 150px);
+            min-height: 560px;
+        }
+        .opencode-agent-error {
+            margin: 24px;
+            color: #0f172a;
+            font: 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+        .opencode-agent-error code {
+            color: #0369a1;
+        }
+        .opencode-agent-frame {
+            width: 100%;
+            height: 100%;
+            border: 0;
+            display: block;
+        }
+        .opencode-agent-shell {
+            position: relative;
+            height: 100%;
+        }
+        .opencode-agent-welcome {
+            position: absolute;
+            inset: 0;
+            z-index: 20;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            background: rgba(0, 0, 0, 0.48);
+            color: #111827;
+        }
+        .opencode-agent-welcome[hidden] {
+            display: none;
+        }
+        .opencode-agent-welcome-panel {
+            width: min(720px, 100%);
+            max-height: min(720px, calc(100vh - 190px));
+            overflow: auto;
+            border-radius: 8px;
+            border: 1px solid #d1d5db;
+            background: Canvas;
+            color: CanvasText;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.32);
+            padding: 24px;
+            font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+        .opencode-agent-welcome-panel h1 {
+            margin: 0 0 10px;
+            font-size: 22px;
+            line-height: 1.25;
+        }
+        .opencode-agent-welcome-panel p {
+            margin: 0 0 14px;
+        }
+        .opencode-agent-welcome-panel ul {
+            margin: 0 0 16px 20px;
+            padding: 0;
+        }
+        .opencode-agent-welcome-panel li {
+            margin: 0 0 8px;
+        }
+        .opencode-agent-welcome-warning {
+            margin: 16px 0;
+            padding: 12px 14px;
+            border: 1px solid #f59e0b;
+            border-radius: 6px;
+            background: color-mix(in srgb, #f59e0b 12%, Canvas);
+        }
+        .opencode-agent-welcome-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+        }
+        .opencode-agent-welcome button {
+            cursor: pointer;
+            border: 1px solid #2563eb;
+            border-radius: 6px;
+            background: #2563eb;
+            color: #fff;
+            padding: 8px 14px;
+            font-weight: 600;
+        }
+        @media (max-width: 700px) {
+            .opencode-agent-welcome {
+                padding: 12px;
+            }
+            .opencode-agent-welcome-panel {
+                max-height: calc(100vh - 170px);
+                padding: 18px;
+            }
+        }
+    </style>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} opencode-agent{% endblock %}
+
+{% block content %}
+    <div id="content-main">
+        {% if error %}
+            <div class="opencode-agent-error">
+                {{ error }}
+                {% if command %}<br><br><code>{{ command }}</code>{% endif %}
+            </div>
+        {% else %}
+            <script>
+                (() => {
+                    const workdir = "{{ workdir|escapejs }}";
+                    const recentSessionId = "{{ recent_session_id|escapejs }}";
+                    const merge = (left, right) => {
+                        if (!left || typeof left !== "object" || Array.isArray(left)) return right;
+                        const out = {...left};
+                        for (const [key, value] of Object.entries(right)) {
+                            out[key] = value && typeof value === "object" && !Array.isArray(value) ? merge(out[key], value) : value;
+                        }
+                        return out;
+                    };
+                    const seed = (key, value) => {
+                        try {
+                            localStorage.setItem(key, JSON.stringify(merge(JSON.parse(localStorage.getItem(key) || "{}"), value)));
+                        } catch {
+                            localStorage.setItem(key, JSON.stringify(value));
+                        }
+                    };
+                    const setJSON = (key, value) => localStorage.setItem(key, JSON.stringify(value));
+                    const page = {
+                        activeProject: workdir,
+                        activeWorkspace: workdir,
+                        gettingStartedDismissed: true,
+                        workspaceExpanded: {[workdir]: true},
+                    };
+                    if (recentSessionId) {
+                        page.lastProjectSession = {[workdir]: {directory: workdir, id: recentSessionId, at: Date.now()}};
+                    }
+                    seed("opencode.global.dat:layout.page", page);
+                    seed("opencode.global.dat:layout", {
+                        sidebar: {opened: true, width: 280},
+                        fileTree: {opened: true, width: 280, tab: "all"},
+                    });
+                    const serverKey = `${location.origin}/admin/agent/opencode`;
+                    setJSON("opencode.global.dat:server", {
+                        list: [],
+                        projects: {
+                            [serverKey]: [{worktree: workdir, expanded: true}],
+                        },
+                        lastProject: {
+                            [serverKey]: workdir,
+                        },
+                    });
+                    localStorage.setItem("opencode.settings.dat:defaultServerUrl", serverKey);
+                })();
+            </script>
+            <div class="opencode-agent-shell">
+                <iframe src="{{ proxy_url }}" title="OpenCode Agent" class="opencode-agent-frame"></iframe>
+                <div class="opencode-agent-welcome" id="opencode-agent-welcome" hidden>
+                    <div class="opencode-agent-welcome-panel" role="dialog" aria-modal="true" aria-labelledby="opencode-agent-welcome-title">
+                        <h1 id="opencode-agent-welcome-title">ArchiveBox AI Agent</h1>
+                        <p>This agent can work directly with your ArchiveBox collection. It can inspect the crawl database, create and monitor crawls, run maintenance operations, answer research questions, query archived data, and help with complex collection workflows.</p>
+                        <p>Example prompts:</p>
+                        <ul>
+                            <li>Archive this list of URLs with depth 0, then report which ones failed and why.</li>
+                            <li>Find snapshots from the last month that failed PDF or screenshot extraction and retry them.</li>
+                            <li>Create a constrained crawl for this site, avoid login/privacy/sitemap URLs, and watch the logs as it runs.</li>
+                            <li>Summarize what my collection contains about this topic and link to the best saved pages.</li>
+                        </ul>
+                        <div class="opencode-agent-welcome-warning">
+                            The agent has unrestricted access to this collection and can make destructive edits. Review requests carefully. Permission settings can be changed from the OpenCode gear icon in the lower left.
+                        </div>
+                        <div class="opencode-agent-welcome-actions">
+                            <button type="button" id="opencode-agent-welcome-dismiss">Start using Agent</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <script>
+                (() => {
+                    const key = "archivebox.opencode.agentWelcomeDismissed.v1";
+                    const welcome = document.getElementById("opencode-agent-welcome");
+                    const dismiss = document.getElementById("opencode-agent-welcome-dismiss");
+                    if (!welcome || !dismiss) return;
+                    if (localStorage.getItem(key) !== "1") {
+                        welcome.hidden = false;
+                    }
+                    dismiss.addEventListener("click", () => {
+                        localStorage.setItem(key, "1");
+                        welcome.hidden = true;
+                    });
+                })();
+            </script>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/abx_plugins/plugins/opencode/templates/agent.html
+++ b/abx_plugins/plugins/opencode/templates/agent.html
@@ -126,6 +126,20 @@
                 (() => {
                     const workdir = "{{ workdir|escapejs }}";
                     const recentSessionId = "{{ recent_session_id|escapejs }}";
+                    const storage = {
+                        get(key) {
+                            try { return localStorage.getItem(key); } catch { return null; }
+                        },
+                        set(key, value) {
+                            try { localStorage.setItem(key, value); } catch { /* Persistence is optional. */ }
+                        },
+                    };
+                    const readJSON = (key) => {
+                        try {
+                            const value = JSON.parse(storage.get(key) || "{}");
+                            return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+                        } catch { return {}; }
+                    };
                     const merge = (left, right) => {
                         if (!left || typeof left !== "object" || Array.isArray(left)) return right;
                         const out = {...left};
@@ -135,13 +149,8 @@
                         return out;
                     };
                     const seed = (key, value) => {
-                        try {
-                            localStorage.setItem(key, JSON.stringify(merge(JSON.parse(localStorage.getItem(key) || "{}"), value)));
-                        } catch {
-                            localStorage.setItem(key, JSON.stringify(value));
-                        }
+                        storage.set(key, JSON.stringify(merge(readJSON(key), value)));
                     };
-                    const setJSON = (key, value) => localStorage.setItem(key, JSON.stringify(value));
                     const page = {
                         activeProject: workdir,
                         activeWorkspace: workdir,
@@ -156,22 +165,38 @@
                         sidebar: {opened: true, width: 280},
                         fileTree: {opened: true, width: 280, tab: "all"},
                     });
-                    const serverKey = `${location.origin}/admin/agent/opencode`;
-                    setJSON("opencode.global.dat:server", {
-                        list: [],
+                    const serverKey = `${location.origin}{{ proxy_prefix|escapejs }}`;
+                    const server = readJSON("opencode.global.dat:server");
+                    const projects = Array.isArray(server.projects?.[serverKey]) ? server.projects[serverKey] : [];
+                    if (!projects.some(project => project.worktree === workdir)) {
+                        projects.push({worktree: workdir, expanded: true});
+                    }
+                    seed("opencode.global.dat:server", {
+                        list: server.list || [],
                         projects: {
-                            [serverKey]: [{worktree: workdir, expanded: true}],
+                            [serverKey]: projects,
                         },
                         lastProject: {
                             [serverKey]: workdir,
                         },
                     });
-                    localStorage.setItem("opencode.settings.dat:defaultServerUrl", serverKey);
+                    storage.set("opencode.settings.dat:defaultServerUrl", serverKey);
+                    document.addEventListener("DOMContentLoaded", () => {
+                        const key = "archivebox.opencode.agentWelcomeDismissed.v1";
+                        const welcome = document.getElementById("opencode-agent-welcome");
+                        const dismiss = document.getElementById("opencode-agent-welcome-dismiss");
+                        if (!welcome || !dismiss) return;
+                        welcome.hidden = storage.get(key) === "1";
+                        dismiss.addEventListener("click", () => {
+                            storage.set(key, "1");
+                            welcome.hidden = true;
+                        });
+                    });
                 })();
             </script>
             <div class="opencode-agent-shell">
                 <iframe src="{{ proxy_url }}" title="OpenCode Agent" class="opencode-agent-frame"></iframe>
-                <div class="opencode-agent-welcome" id="opencode-agent-welcome" hidden>
+                <div class="opencode-agent-welcome" id="opencode-agent-welcome">
                     <div class="opencode-agent-welcome-panel" role="dialog" aria-modal="true" aria-labelledby="opencode-agent-welcome-title">
                         <h1 id="opencode-agent-welcome-title">ArchiveBox AI Agent</h1>
                         <p>This agent can work directly with your ArchiveBox collection. It can inspect the crawl database, create and monitor crawls, run maintenance operations, answer research questions, query archived data, and help with complex collection workflows.</p>
@@ -191,21 +216,6 @@
                     </div>
                 </div>
             </div>
-            <script>
-                (() => {
-                    const key = "archivebox.opencode.agentWelcomeDismissed.v1";
-                    const welcome = document.getElementById("opencode-agent-welcome");
-                    const dismiss = document.getElementById("opencode-agent-welcome-dismiss");
-                    if (!welcome || !dismiss) return;
-                    if (localStorage.getItem(key) !== "1") {
-                        welcome.hidden = false;
-                    }
-                    dismiss.addEventListener("click", () => {
-                        localStorage.setItem(key, "1");
-                        welcome.hidden = true;
-                    });
-                })();
-            </script>
         {% endif %}
     </div>
 {% endblock %}

--- a/abx_plugins/plugins/opencode/templates/agent.html
+++ b/abx_plugins/plugins/opencode/templates/agent.html
@@ -181,17 +181,6 @@
                         },
                     });
                     storage.set("opencode.settings.dat:defaultServerUrl", serverKey);
-                    document.addEventListener("DOMContentLoaded", () => {
-                        const key = "archivebox.opencode.agentWelcomeDismissed.v1";
-                        const welcome = document.getElementById("opencode-agent-welcome");
-                        const dismiss = document.getElementById("opencode-agent-welcome-dismiss");
-                        if (!welcome || !dismiss) return;
-                        welcome.hidden = storage.get(key) === "1";
-                        dismiss.addEventListener("click", () => {
-                            storage.set(key, "1");
-                            welcome.hidden = true;
-                        });
-                    });
                 })();
             </script>
             <div class="opencode-agent-shell">
@@ -216,6 +205,18 @@
                     </div>
                 </div>
             </div>
+            <script>
+                (() => {
+                    const key = "archivebox.opencode.agentWelcomeDismissed.v1";
+                    const welcome = document.getElementById("opencode-agent-welcome");
+                    const dismiss = document.getElementById("opencode-agent-welcome-dismiss");
+                    try { welcome.hidden = localStorage.getItem(key) === "1"; } catch { /* Keep the warning visible. */ }
+                    dismiss.addEventListener("click", () => {
+                        welcome.hidden = true;
+                        try { localStorage.setItem(key, "1"); } catch { /* Persistence is optional. */ }
+                    });
+                })();
+            </script>
         {% endif %}
     </div>
 {% endblock %}

--- a/abx_plugins/plugins/opencode/templates/navigation.html
+++ b/abx_plugins/plugins/opencode/templates/navigation.html
@@ -1,0 +1,4 @@
+{% if user.is_authenticated and user.is_superuser and request.archivebox_config.OPENCODE_ENABLED %}
+    <a href="/admin/agent" class="navbar-item navbar-ai">💬 AI</a>
+    <span class="navbar-separator" aria-hidden="true">|</span>
+{% endif %}

--- a/abx_plugins/plugins/opencode/templates/navigation.html
+++ b/abx_plugins/plugins/opencode/templates/navigation.html
@@ -1,4 +1,4 @@
 {% if user.is_authenticated and user.is_superuser and request.archivebox_config.OPENCODE_ENABLED %}
-    <a href="/admin/agent" class="navbar-item navbar-ai">💬 AI</a>
+    <a href="{% url 'opencode-agent' %}" class="navbar-item navbar-ai">💬 AI</a>
     <span class="navbar-separator" aria-hidden="true">|</span>
 {% endif %}

--- a/abx_plugins/plugins/opencode/tests/test_runtime.py
+++ b/abx_plugins/plugins/opencode/tests/test_runtime.py
@@ -1,0 +1,107 @@
+import json
+import signal
+import subprocess
+
+import pytest
+
+
+def test_stop_owned_process_falls_back_for_stopped_process_without_dedicated_group():
+    from abx_plugins.plugins.opencode import runtime
+
+    process = subprocess.Popen(["sleep", "60"])
+    try:
+        process.send_signal(signal.SIGSTOP)
+        runtime._stop_owned_process(process)
+        assert process.returncode == -signal.SIGTERM
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+
+def test_opencode_state_dir_is_separate_from_workdir(tmp_path):
+    from abx_plugins.plugins.opencode import runtime
+
+    workdir = tmp_path / "workdir"
+    state_dir = tmp_path / "state"
+    settings = runtime._settings(
+        {
+            "OPENCODE_WORKDIR": str(workdir),
+            "OPENCODE_STATE_DIR": str(state_dir),
+        },
+    )
+    runtime._ensure_project_files(settings)
+
+    assert settings["workdir"] == workdir
+    assert settings["opencode_dir"] == state_dir
+    assert settings["config_home"] == state_dir / "config"
+    assert settings["data_home"] == state_dir / "data"
+    assert settings["state_home"] == state_dir / "state"
+    editable_skill = state_dir / "SKILL.md"
+    loaded_skill = (
+        state_dir / "config" / "opencode" / "skills" / "archivebox" / "SKILL.md"
+    )
+    assert editable_skill.exists()
+    assert loaded_skill.is_symlink()
+    assert loaded_skill.resolve() == editable_skill.resolve()
+    assert (
+        f"ArchiveBox collection directory: {settings['archivebox_data_dir']}"
+        in editable_skill.read_text()
+    )
+    opencode_config = json.loads(
+        (state_dir / "config" / "opencode" / "opencode.jsonc").read_text(),
+    )
+    assert opencode_config["model"] == "opencode/big-pickle"
+    assert opencode_config["snapshot"] is False
+
+
+@pytest.mark.parametrize(
+    "existing_config",
+    [
+        '{"model": "anthropic/claude-sonnet-4-5"}\n',
+        '{\n  // Keep the administrator-selected model.\n  "model": "anthropic/claude-sonnet-4-5",\n}\n',
+        '{\n  // Schema-only files are still user-owned.\n  "$schema": "https://opencode.ai/config.json",\n}\n',
+    ],
+)
+def test_opencode_preserves_existing_config(tmp_path, existing_config):
+    from abx_plugins.plugins.opencode import runtime
+
+    state_dir = tmp_path / "state"
+    config_path = state_dir / "config" / "opencode" / "opencode.jsonc"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(existing_config)
+
+    runtime._ensure_project_files(
+        runtime._settings(
+            {
+                "OPENCODE_WORKDIR": str(tmp_path / "workdir"),
+                "OPENCODE_STATE_DIR": str(state_dir),
+            },
+        ),
+    )
+
+    assert config_path.read_text() == existing_config
+
+
+def test_opencode_defaults_to_the_archivebox_collection():
+    from abx_plugins.plugins.opencode import runtime
+
+    settings = runtime._settings({})
+
+    assert settings["opencode_dir"] == settings["archivebox_data_dir"] / "opencode"
+    assert settings["workdir"] == settings["archivebox_data_dir"]
+    assert settings["timeout"] == 120
+
+
+def test_opencode_rewrites_vite_preload_assets():
+    from abx_plugins.plugins.opencode import runtime
+
+    body = b'const BL="modulepreload",UL=function(t){return"/"+t};const icon="/assets/sprite.svg#anthropic"'
+    rewritten = runtime._rewrite_text(
+        body,
+        {"origin": "http://127.0.0.1:4096"},
+    ).decode()
+
+    assert 'return"/"+t' not in rewritten
+    assert 'return"/admin/agent/opencode/"+t' in rewritten
+    assert '"/admin/agent/opencode/assets/sprite.svg#anthropic"' in rewritten

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "uv>=0.8.22",
 ]
 
+[project.optional-dependencies]
+opencode = ["httpx>=0.28.1", "requests>=2.32.3"]
+
 [dependency-groups]
 dev = [
     "pytest>=8.3.3,<9",  # pytest-codeblocks 0.17.0 still uses the pre-pytest-9 collect hook signature.
@@ -35,6 +38,7 @@ dev = [
     "pytest-sugar>=1.0.0",
     "pytest-timeout>=2.3.1",
     "feedparser>=6.0.0",
+    "httpx>=0.28.1",
     "requests>=2.28.0",
     "pydantic-settings>=2.0.0",
     "psutil>=7.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -3,13 +3,13 @@ revision = 3
 requires-python = ">=3.12, <3.15"
 
 [options]
-exclude-newer = "2026-08-28T19:57:49.093770047Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P5D"
 
 [options.exclude-newer-package]
 abx-plugins = "2100-01-01T00:00:00Z"
 abxpkg = "2100-01-01T00:00:00Z"
-abxbus = { timestamp = "2026-09-02T19:57:48.093784454Z", span = "PT1S" }
+abxbus = { timestamp = "0001-01-01T00:00:00Z", span = "PT1S" }
 
 [[package]]
 name = "abx-plugins"
@@ -23,9 +23,16 @@ dependencies = [
     { name = "uv" },
 ]
 
+[package.optional-dependencies]
+opencode = [
+    { name = "httpx" },
+    { name = "requests" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "feedparser" },
+    { name = "httpx" },
     { name = "jinja2" },
     { name = "prek" },
     { name = "psutil" },
@@ -46,14 +53,18 @@ dev = [
 requires-dist = [
     { name = "abxbus", specifier = "==2.5.56" },
     { name = "abxpkg", specifier = "==1.12.117" },
+    { name = "httpx", marker = "extra == 'opencode'", specifier = ">=0.28.1" },
     { name = "imagesize", specifier = ">=2.0.0" },
+    { name = "requests", marker = "extra == 'opencode'", specifier = ">=2.32.3" },
     { name = "rich-click", specifier = ">=1.9.7" },
     { name = "uv", specifier = ">=0.8.22" },
 ]
+provides-extras = ["opencode"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "feedparser", specifier = ">=6.0.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "prek", specifier = ">=0.3.6" },
     { name = "psutil", specifier = ">=7.2.1" },
@@ -94,9 +105,9 @@ dependencies = [
     { name = "rich-click" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/35/bbfaccae109328c716cea4e0cdbf2d2dc5975f448203bb3f4daa605591a6/abxpkg-1.12.117.tar.gz", hash = "sha256:4d88cc293f343eee2be7ecaab1203dfbc20571a4a39b2afa2f866c9ef8032dec", size = 239387 }
+sdist = { url = "https://files.pythonhosted.org/packages/00/35/bbfaccae109328c716cea4e0cdbf2d2dc5975f448203bb3f4daa605591a6/abxpkg-1.12.117.tar.gz", hash = "sha256:4d88cc293f343eee2be7ecaab1203dfbc20571a4a39b2afa2f866c9ef8032dec", size = 239387, upload-time = "2026-09-02T19:57:26.142Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/46/372be1f8fa915eb254ad865b97fb41073acdb5573dbce3e23a6083417d87/abxpkg-1.12.117-py3-none-any.whl", hash = "sha256:76ec8afaac7b2d7aece7bdda2bbf606e6373db51eb4dcb906008052d09e59577", size = 253749 },
+    { url = "https://files.pythonhosted.org/packages/73/46/372be1f8fa915eb254ad865b97fb41073acdb5573dbce3e23a6083417d87/abxpkg-1.12.117-py3-none-any.whl", hash = "sha256:76ec8afaac7b2d7aece7bdda2bbf606e6373db51eb4dcb906008052d09e59577", size = 253749, upload-time = "2026-09-02T19:57:27.437Z" },
 ]
 
 [[package]]
@@ -106,6 +117,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]
@@ -209,6 +233,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves the OpenCode process lifecycle, dependency resolution, isolated state, session setup, proxying, defaults, skill text, and UI templates out of ArchiveBox into the standalone plugin. Runtime imports remain lazy and framework-independent. The host retains authentication and Django response conversion only.

Contains streaming exceptions within the optional service and closes upstream responses. No forced Git initialization or default checkpointing. Existing user configuration is preserved.

Verification: 8 plugin runtime/dependency-boundary tests passed; isolated wheel install verified runtime, templates, and the opencode extra; all pre-commit checks passed. ArchiveBox integration tests exercise real OpenCode processes, damaged installations, filesystem errors, and template failures. Paired ArchiveBox change follows this plugin release.

This relocates the existing proxy behavior; it does not claim to solve upstream subpath or WebSocket support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the OpenCode runtime and UI into the plugin, so ArchiveBox no longer manages the OpenCode process. The plugin now owns process lifecycle, dependency resolution, session setup, proxying, defaults, skill text, and UI templates; ArchiveBox only supplies authentication and Django response conversion.

- Runtime imports stay lazy and framework-independent; importing the plugin does not start OpenCode.
- No forced Git initialization or default checkpointing; existing user configuration is preserved.
- Browser-side servers and projects survive navigation; the agent warning dismissal applies synchronously, and unavailable or full browser storage cannot suppress it or block dismissal.
- Streaming exceptions are contained and upstream responses are closed.
- Adds an `opencode` package extra for the HTTP clients (`httpx` and `requests`).
- This relocates existing proxy behavior; it does not claim to solve upstream subpath or WebSocket support.

**Migration**
- A paired ArchiveBox change is required; this plugin release should land first.

<sup>Written for commit a0ca154e601a40ab9a2f5ea02b18477623776cb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

