### PR TITLE
Avoid repeated OpenCode asset rewriting and allow private browser caching

### DIFF
--- a/abx_plugins/plugins/opencode/runtime.py
+++ b/abx_plugins/plugins/opencode/runtime.py
@@ -11,7 +11,6 @@ import signal
 import subprocess
 import threading
 import time
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -23,6 +22,7 @@ _PROCESS: subprocess.Popen | None = None
 _PROCESS_READY: subprocess.Popen | None = None
 _PROCESS_LOCK = threading.Lock()
 _SESSION_LOCK = threading.Lock()
+_ASSETS: dict[tuple[str, str, bytes], tuple[bytes, str]] = {}
 _LOGGER = logging.getLogger(__name__)
 _PROXY_PREFIX = "/admin/agent/opencode"
 _PROXY_PREFIX_NO_SLASH_REGEX = _PROXY_PREFIX.lstrip("/").replace("/", r"\/")
@@ -427,7 +427,6 @@ def _proxy_url(settings: dict, path: str | None) -> str:
     return settings["origin"] + "/" + (path or "").lstrip("/")
 
 
-@lru_cache(maxsize=8)
 def _rewrite_text(body: bytes, origin: str) -> bytes:
     text = body.decode("utf-8", errors="replace")
     text = text.replace(origin, _PROXY_PREFIX)
@@ -624,18 +623,26 @@ def proxy(settings: dict, method: str, path: str, params, headers, body: bytes):
     ) as upstream:
         content = upstream.content
         response_headers = _response_headers(upstream, settings)
-        if any(
-            upstream.headers.get("Content-Type", "").startswith(prefix)
-            for prefix in _TEXT_CONTENT_TYPES
-        ):
-            rewrite = _rewrite_text if path.startswith("assets/") else _rewrite_text.__wrapped__
-            content = rewrite(content, settings["origin"])
+        asset = method == "GET" and path.startswith("assets/") and upstream.status_code == 200
+        key = (settings["origin"], upstream.headers.get("Content-Type", ""), hashlib.sha256(content).digest()) if asset else None
+        cached = _ASSETS.get(key)
+        if cached is not None:
+            content, etag = cached
+        else:
+            if any(upstream.headers.get("Content-Type", "").startswith(prefix) for prefix in _TEXT_CONTENT_TYPES):
+                content = _rewrite_text(content, settings["origin"])
+            if key is not None:
+                etag = f'"{hashlib.sha256(content).hexdigest()}"'
+                # Keep only outputs, not a second copy of each multi-MB input.
+                if len(_ASSETS) >= 8:
+                    _ASSETS.pop(next(iter(_ASSETS), None), None)
+                _ASSETS[key] = content, etag
         response_headers["Cache-Control"] = "no-store"
-        if method == "GET" and path.startswith("assets/") and upstream.status_code == 200:
+        if asset:
             # Hashed build assets contain no session data. Cache only privately;
             # API responses and the HTML entrypoint must always remain fresh.
             response_headers["Cache-Control"] = "private, max-age=3600"
-            response_headers["ETag"] = etag = f'"{hashlib.sha256(content).hexdigest()}"'
+            response_headers["ETag"] = etag
             validators = {tag.strip().removeprefix("W/") for tag in headers.get("If-None-Match", "").split(",")}
             if etag in validators or "*" in validators:
                 return 304, response_headers, b""

--- a/abx_plugins/plugins/opencode/runtime.py
+++ b/abx_plugins/plugins/opencode/runtime.py
@@ -27,12 +27,10 @@ _LOGGER = logging.getLogger(__name__)
 _PROXY_PREFIX = "/admin/agent/opencode"
 _PROXY_PREFIX_NO_SLASH_REGEX = _PROXY_PREFIX.lstrip("/").replace("/", r"\/")
 _CONFIG_PATH = Path(__file__).with_name("config.json")
-_DEFAULT_MODEL = "opencode/big-pickle"
-_DEFAULT_CONFIG = f'''{{
+_DEFAULT_CONFIG = '''{
   "$schema": "https://opencode.ai/config.json",
-  "model": "{_DEFAULT_MODEL}",
   "snapshot": false
-}}
+}
 '''
 
 _TEXT_CONTENT_TYPES = (

--- a/abx_plugins/plugins/opencode/runtime.py
+++ b/abx_plugins/plugins/opencode/runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import base64
+import hashlib
 import logging
 import os
 import re
@@ -10,6 +11,7 @@ import signal
 import subprocess
 import threading
 import time
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -425,9 +427,10 @@ def _proxy_url(settings: dict, path: str | None) -> str:
     return settings["origin"] + "/" + (path or "").lstrip("/")
 
 
-def _rewrite_text(body: bytes, settings: dict) -> bytes:
+@lru_cache(maxsize=8)
+def _rewrite_text(body: bytes, origin: str) -> bytes:
     text = body.decode("utf-8", errors="replace")
-    text = text.replace(settings["origin"], _PROXY_PREFIX)
+    text = text.replace(origin, _PROXY_PREFIX)
     # Configure the native router, not browser history or pathname. Minifier
     # identifiers change between builds; the public router prop does not.
     text = re.sub(
@@ -474,6 +477,8 @@ def _response_headers(upstream: requests.Response, settings: dict) -> dict[str, 
             "content-length",
             "content-encoding",
             "x-frame-options",
+            "etag",
+            "cache-control",
         }:
             continue
         if lower == "location":
@@ -623,6 +628,15 @@ def proxy(settings: dict, method: str, path: str, params, headers, body: bytes):
             upstream.headers.get("Content-Type", "").startswith(prefix)
             for prefix in _TEXT_CONTENT_TYPES
         ):
-            content = _rewrite_text(content, settings)
+            rewrite = _rewrite_text if path.startswith("assets/") else _rewrite_text.__wrapped__
+            content = rewrite(content, settings["origin"])
         response_headers["Cache-Control"] = "no-store"
+        if method == "GET" and path.startswith("assets/") and upstream.status_code == 200:
+            # Hashed build assets contain no session data. Cache only privately;
+            # API responses and the HTML entrypoint must always remain fresh.
+            response_headers["Cache-Control"] = "private, max-age=3600"
+            response_headers["ETag"] = etag = f'"{hashlib.sha256(content).hexdigest()}"'
+            validators = {tag.strip().removeprefix("W/") for tag in headers.get("If-None-Match", "").split(",")}
+            if etag in validators or "*" in validators:
+                return 304, response_headers, b""
         return upstream.status_code, response_headers, content

--- a/abx_plugins/plugins/opencode/tests/test_runtime.py
+++ b/abx_plugins/plugins/opencode/tests/test_runtime.py
@@ -51,7 +51,7 @@ def test_opencode_state_dir_is_separate_from_workdir(tmp_path):
     opencode_config = json.loads(
         (state_dir / "config" / "opencode" / "opencode.jsonc").read_text(),
     )
-    assert opencode_config["model"] == "opencode/big-pickle"
+    assert "model" not in opencode_config
     assert opencode_config["snapshot"] is False
 
 

--- a/abx_plugins/plugins/opencode/tests/test_runtime.py
+++ b/abx_plugins/plugins/opencode/tests/test_runtime.py
@@ -99,7 +99,7 @@ def test_opencode_rewrites_vite_preload_assets():
     body = b'const BL="modulepreload",UL=function(t){return"/"+t};const icon="/assets/sprite.svg#anthropic"'
     rewritten = runtime._rewrite_text(
         body,
-        {"origin": "http://127.0.0.1:4096"},
+        "http://127.0.0.1:4096",
     ).decode()
 
     assert 'return"/"+t' not in rewritten


### PR DESCRIPTION
## Changes
- Memoize only static asset text rewrites with one bounded stdlib cache on the existing function; no API response or user file content cache.
- Give build assets private browser caching and body-based ETags/304 revalidation. HTML and API responses remain no-store.
- Drop upstream validators for rewritten representations.

## Verification
- Existing plugin runtime tests: 7 passed.
- Real OpenCode integration/browser suite: 25 passed; the five incomplete-install tests exposed a pre-existing test source-path ordering bug, corrected and all five passed separately in the accompanying ArchiveBox PR.
- New real-upstream asset regression fails against published plugin and passes with this change.
- Live DigestBox measurements and upstream provider-catalog performance work are ongoing separately; no provider-specific proxy caching added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously every OpenCode text response was rewritten and marked no-store. Now static build assets are rewritten once in a small bounded cache and sent with `private, max-age=3600` plus body-derived ETags so browsers can revalidate with 304s. OpenCode also no longer pins the retired `big-pickle` model and lets the provider select an available one.

- Caches only hashed asset rewrites; HTML, API responses, and other dynamic text still rewrite per request and stay no-store.
- Drops upstream `etag` and `cache-control` headers for rewritten responses and replaces them with validators for the rewritten content.

<sup>Written for commit 4d938e6ba0baa29140c055871debb16a1676a213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

