### PR TITLE
Fix formatting and type checks for OpenCode asset cache

### DIFF
--- a/abx_plugins/plugins/opencode/runtime.py
+++ b/abx_plugins/plugins/opencode/runtime.py
@@ -27,11 +27,11 @@ _LOGGER = logging.getLogger(__name__)
 _PROXY_PREFIX = "/admin/agent/opencode"
 _PROXY_PREFIX_NO_SLASH_REGEX = _PROXY_PREFIX.lstrip("/").replace("/", r"\/")
 _CONFIG_PATH = Path(__file__).with_name("config.json")
-_DEFAULT_CONFIG = '''{
+_DEFAULT_CONFIG = """{
   "$schema": "https://opencode.ai/config.json",
   "snapshot": false
 }
-'''
+"""
 
 _TEXT_CONTENT_TYPES = (
     "text/",
@@ -621,13 +621,28 @@ def proxy(settings: dict, method: str, path: str, params, headers, body: bytes):
     ) as upstream:
         content = upstream.content
         response_headers = _response_headers(upstream, settings)
-        asset = method == "GET" and path.startswith("assets/") and upstream.status_code == 200
-        key = (settings["origin"], upstream.headers.get("Content-Type", ""), hashlib.sha256(content).digest()) if asset else None
+        asset = (
+            method == "GET"
+            and path.startswith("assets/")
+            and upstream.status_code == 200
+        )
+        key = (
+            (
+                settings["origin"],
+                upstream.headers.get("Content-Type", ""),
+                hashlib.sha256(content).digest(),
+            )
+            if asset
+            else None
+        )
         cached = _ASSETS.get(key)
         if cached is not None:
             content, etag = cached
         else:
-            if any(upstream.headers.get("Content-Type", "").startswith(prefix) for prefix in _TEXT_CONTENT_TYPES):
+            if any(
+                upstream.headers.get("Content-Type", "").startswith(prefix)
+                for prefix in _TEXT_CONTENT_TYPES
+            ):
                 content = _rewrite_text(content, settings["origin"])
             if key is not None:
                 etag = f'"{hashlib.sha256(content).hexdigest()}"'
@@ -641,7 +656,10 @@ def proxy(settings: dict, method: str, path: str, params, headers, body: bytes):
             # API responses and the HTML entrypoint must always remain fresh.
             response_headers["Cache-Control"] = "private, max-age=3600"
             response_headers["ETag"] = etag
-            validators = {tag.strip().removeprefix("W/") for tag in headers.get("If-None-Match", "").split(",")}
+            validators = {
+                tag.strip().removeprefix("W/")
+                for tag in headers.get("If-None-Match", "").split(",")
+            }
             if etag in validators or "*" in validators:
                 return 304, response_headers, b""
         return upstream.status_code, response_headers, content

--- a/abx_plugins/plugins/opencode/runtime.py
+++ b/abx_plugins/plugins/opencode/runtime.py
@@ -635,9 +635,9 @@ def proxy(settings: dict, method: str, path: str, params, headers, body: bytes):
             if asset
             else None
         )
-        cached = _ASSETS.get(key)
+        cached = _ASSETS.get(key) if key is not None else None
         if cached is not None:
-            content, etag = cached
+            content = cached[0]
         else:
             if any(
                 upstream.headers.get("Content-Type", "").startswith(prefix)
@@ -645,21 +645,21 @@ def proxy(settings: dict, method: str, path: str, params, headers, body: bytes):
             ):
                 content = _rewrite_text(content, settings["origin"])
             if key is not None:
-                etag = f'"{hashlib.sha256(content).hexdigest()}"'
+                cached = content, f'"{hashlib.sha256(content).hexdigest()}"'
                 # Keep only outputs, not a second copy of each multi-MB input.
                 if len(_ASSETS) >= 8:
-                    _ASSETS.pop(next(iter(_ASSETS), None), None)
-                _ASSETS[key] = content, etag
+                    _ASSETS.pop(next(iter(_ASSETS), key), None)
+                _ASSETS[key] = cached
         response_headers["Cache-Control"] = "no-store"
-        if asset:
+        if cached is not None:
             # Hashed build assets contain no session data. Cache only privately;
             # API responses and the HTML entrypoint must always remain fresh.
             response_headers["Cache-Control"] = "private, max-age=3600"
-            response_headers["ETag"] = etag
+            response_headers["ETag"] = cached[1]
             validators = {
                 tag.strip().removeprefix("W/")
                 for tag in headers.get("If-None-Match", "").split(",")
             }
-            if etag in validators or "*" in validators:
+            if cached[1] in validators or "*" in validators:
                 return 304, response_headers, b""
         return upstream.status_code, response_headers, content


### PR DESCRIPTION
Follow-up to #69: apply the plugin repository formatter and make the optional-key/cached-response branches explicit to pyright. No new cache layer, assertion relaxation, or behavior change.

Validation: pyright 0 errors; ruff check/format pass; real installed-OpenCode asset/ETag test passes. This corrects the pre-commit failure reported on the previous PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the repository formatter to the OpenCode proxy and makes the optional-key/cached-response branches explicit to pyright. Fixes the pre-commit failure from the previous PR with no behavior change.

<sup>Written for commit 25070cb8caac19b5673d07a8b503ffc5fdd94ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-plugins/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

